### PR TITLE
approveFor with amount = 0 allowed, decrease to cap=0 does not un-authorize

### DIFF
--- a/contracts/ERC20Authorized.sol
+++ b/contracts/ERC20Authorized.sol
@@ -20,7 +20,12 @@ contract ERC20Authorized is ERC20, IERC20Authorized
     //
 
     // Cap = 0 is the default and means no authorization. Usage: authorizedCaps[owner][authorized]
-    mapping(address => mapping(address => mapping(address => uint256))) public authorizedCaps;
+    struct AuthorizationEntry
+    {
+        uint256 cap;
+        bool isAuthorized;
+    }
+    mapping(address => mapping(address => mapping(address => AuthorizationEntry))) public authorizationData;
 
 
     /* for E: Add a constructor and:
@@ -72,7 +77,6 @@ contract ERC20Authorized is ERC20, IERC20Authorized
 
     /// authorize docstring - assuming addr is the address of the token contract
     function authorize(address owner, address authorized, uint256 cap) public
-        validCap(cap)
         validAddress(owner)
         validAddress(authorized)
     {
@@ -80,14 +84,15 @@ contract ERC20Authorized is ERC20, IERC20Authorized
         require(owner != authorized, "Self authorization is prohibited");
         require(!isAuthorized(msg.sender, owner, authorized), "Address already authorized, call increase/decrease instead");
         require(IERC20(msg.sender).balanceOf(owner) >= cap, "Cannot authorize more than balance");
-        authorizedCaps[msg.sender][owner][authorized] = cap;
+        authorizationData[msg.sender][owner][authorized].isAuthorized = true;
+        authorizationData[msg.sender][owner][authorized].cap = cap;
         emit Authorization(msg.sender, owner, authorized, cap);
     }
 
     /// This is the read function
     function getAuthorizedCap(address addr, address owner, address authorized) view public returns (uint256)
     {
-        return authorizedCaps[addr][owner][authorized];
+        return authorizationData[addr][owner][authorized].cap;
     }
 
     function increaseAuthorizedCap(address owner, address authorized, uint256 addedCap) public
@@ -95,7 +100,7 @@ contract ERC20Authorized is ERC20, IERC20Authorized
         validCap(addedCap)
         returns (uint256)
     {
-        uint256 currentCap = authorizedCaps[msg.sender][owner][authorized];
+        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
         unchecked
         {
             uint256 newCap = currentCap + addedCap;
@@ -105,18 +110,15 @@ contract ERC20Authorized is ERC20, IERC20Authorized
                 newCap = type(uint256).max;
             }
             require(IERC20(msg.sender).balanceOf(owner) >= newCap, "Cannot authorize more than balance");
-            authorizedCaps[msg.sender][owner][authorized] = newCap;
+            authorizationData[msg.sender][owner][authorized].cap = newCap;
             emit IncreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
             return newCap;
         }
     }
 
-    function decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) public
-        currentlyAuthorized(msg.sender, owner, authorized)
-        validCap(subtractedCap)
-        returns (uint256)
+    function _decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) public returns (uint256)
     {
-        uint256 currentCap = authorizedCaps[msg.sender][owner][authorized];
+        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
         uint256 newCap;
         if (subtractedCap >= currentCap)
         {
@@ -130,26 +132,34 @@ contract ERC20Authorized is ERC20, IERC20Authorized
                 newCap = currentCap - subtractedCap;
             }
         }
-        authorizedCaps[msg.sender][owner][authorized] = newCap;
+        authorizationData[msg.sender][owner][authorized].cap = newCap;
         emit DecreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
         return newCap;
     }
 
+
+    function decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) public
+        currentlyAuthorized(msg.sender, owner, authorized)
+        validCap(subtractedCap)
+        returns (uint256)
+    {
+        return _decreaseAuthorizedCap(owner, authorized, subtractedCap);
+    }
+
     function isAuthorized(address addr, address owner, address authorized) public view returns (bool)
     {
-        return authorizedCaps[addr][owner][authorized] > 0;
+        return authorizationData[addr][owner][authorized].isAuthorized;
     }
 
     function revokeAuthorization(address owner, address authorized) public
         currentlyAuthorized(msg.sender, owner, authorized)
     {
-        delete authorizedCaps[msg.sender][owner][authorized];
+        delete authorizationData[msg.sender][owner][authorized];
         emit RevokeAuthorization(msg.sender, owner, authorized);
     }
 
     function approveFor(address owner, address authorized, address spender, uint256 amount) public
         currentlyAuthorized(msg.sender, owner, authorized)
-        validCap(amount)
         validAddress(spender)
     {
         // require(isRegistered(msg.sender), "Contract not registered to authorize");
@@ -158,7 +168,10 @@ contract ERC20Authorized is ERC20, IERC20Authorized
         // ERC20 allows to approve more than owner balance, fails only during transfer. So leave this error check out
         //require(IERC20(msg.sender).balanceOf(owner) >= amount, "Owner doesn't have enough balance");
         require(getAuthorizedCap(msg.sender, owner, authorized) >= amount, "Authorized doesn't have enough cap");
-        decreaseAuthorizedCap(owner, authorized, amount);
+        if (amount > 0)
+        {
+            _decreaseAuthorizedCap(owner, authorized, amount);
+        }
         emit ApproveFor(msg.sender, owner,  authorized, amount);
         // Approval itself done by client
     }

--- a/test/ERC20Authorized.t.sol
+++ b/test/ERC20Authorized.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {ERC20Authorized} from "../contracts/ERC20Authorized.sol";
 
 interface IERC20AuthorizedEvents
@@ -70,9 +71,9 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
     {
         deal(address(customToken1), owner, 50);
         vm.prank(address(customToken1));
-        // Not enough tokens to authorize
-        vm.expectRevert();
         erc20Authorized.authorize(owner, authorized1, 0);
+        assertTrue(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
+        assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 0, "Cap should updated after authorize");
     }
 
     function test_authorizeTwice() external
@@ -315,13 +316,14 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         vm.startPrank(address(customToken1));
         erc20Authorized.authorize(owner, authorized1, amount / 2);
         erc20Authorized.decreaseAuthorizedCap(owner, authorized1, amount);
-        // Decrease to 0 un-authorizes
-        assertFalse(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
-        // Cannot increase/decrease after decrease to 0
-        vm.expectRevert();
+        // Decrease to 0 does not un-authorize
+        assertTrue(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
+        assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 0, "Cap should updated after decrease");
+        // Can increase/decrease after decrease to 0
         erc20Authorized.increaseAuthorizedCap(owner, authorized1, amount / 2);
-        vm.expectRevert();
+        assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), amount / 2, "Cap should updated after increase");
         erc20Authorized.decreaseAuthorizedCap(owner, authorized1, amount / 2);
+        assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 0, "Cap should updated after decrease");
     }
 
     function test_approveForUnauthorized() external
@@ -369,8 +371,12 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         deal(address(customToken1), owner, amount);
         vm.startPrank(address(customToken1));
         erc20Authorized.authorize(owner, authorized1, amount / 2);
-        vm.expectRevert();
+        vm.recordLogs();
+        vm.expectEmit(true, true, false, true);
+        emit ApproveFor(address(customToken1), owner,  authorized1, 0);
         erc20Authorized.approveFor(owner, authorized1, authorized2, 0);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 2, "Only 2 events should have been emitted");
     }
 
     function test_approveForAmountMoreThanCap() external
@@ -389,11 +395,14 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         deal(address(customToken1), owner, amount);
         vm.startPrank(address(customToken1));
         erc20Authorized.authorize(owner, authorized1, amount);
+        vm.recordLogs();
         vm.expectEmit(true, true, false, true);
         emit DecreaseAuthorizedCap(address(customToken1), owner,  authorized1, 3 * amount / 4);
         vm.expectEmit(true, true, false, true);
         emit ApproveFor(address(customToken1), owner,  authorized1, amount / 4);
         erc20Authorized.approveFor(owner, authorized1, authorized2, amount / 4);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 4, "Only 4 events should have been emitted");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 3 * amount / 4, "Cap should updated after approveFor");
     }
 
@@ -405,7 +414,8 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, amount);
         assertTrue(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
         erc20Authorized.approveFor(owner, authorized1, authorized2, amount);
-        assertFalse(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
+        assertTrue(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
+        assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 0, "Cap should updated after approveFor");
     }
 
     function test_approveForSameSpenderTwoAuthorizers() external


### PR DESCRIPTION
2 separate commits to make review easier:

1. Add modifier for invalid address (address(0)), and apply to authorize and approveFor. Update tests.

2. Allow approveFor with amount=0, which basically rejects the _allowances of the spender. Differentiate cap=0 and isAuthorized: authorized users can have cap=0, it means they can reject existing approvals of spenders. Update tests.