### PR TITLE
Or/increase decrease client

### DIFF
--- a/contracts/ERC20Authorized.sol
+++ b/contracts/ERC20Authorized.sol
@@ -33,6 +33,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         uint256 cap;
         bool isAuthorized;
     }
+    // TODO: Modify server storage to accommodate retrieving all authorizers of an owner and vice-versa
     mapping(address => mapping(address => mapping(address => AuthorizationEntry))) public authorizationData;
 
     /*
@@ -222,9 +223,9 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         _;
     }
 
-    modifier validAddress(address addr)
+    modifier validAddress(address client)
     {
-        require(addr != address(0), "InvalidAddress");
+        require(client != address(0), "InvalidAddress");
         _;
     }
 
@@ -266,67 +267,80 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         return authorizationData[client][owner][authorized].cap;
     }
 
-    function increaseAuthorizedCap(address owner, address authorized, uint256 addedCap) public
-        onlyRegisteredClient
-        currentlyAuthorized(msg.sender, owner, authorized)
-        validCapAmount(addedCap)
-        returns (uint256)
+    function _getIncreasedCap(uint256 currentCap, uint256 addedCapRequested) internal pure
+        returns (uint256 newCap)
     {
-        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
         unchecked
         {
-            uint256 newCap = currentCap + addedCap;
+            newCap = currentCap + addedCapRequested;
             if (newCap < currentCap)
             {
                 // Overflow occurred
                 newCap = type(uint256).max;
             }
-            if (IERC20(msg.sender).balanceOf(owner) < newCap)
-            {
-                revert InsufficientOwnerBalance(msg.sender, owner, newCap);
-            }
-            authorizationData[msg.sender][owner][authorized].cap = newCap;
-            emit IncreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
-            return newCap;
         }
     }
 
-    function _decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) public
-    onlyRegisteredClient
-    returns (uint256)
+    function increaseAuthorizedCap(address owner, address authorized, uint256 addedCap) public
+        onlyRegisteredClient
+        currentlyAuthorized(msg.sender, owner, authorized)
+        validCapAmount(addedCap)
+        returns (uint256 newCap)
     {
         uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
-        uint256 newCap;
-
-        if (subtractedCap >= currentCap)
+        newCap = _getIncreasedCap(currentCap, addedCap);
+        if (IERC20(msg.sender).balanceOf(owner) < newCap)
         {
+           revert InsufficientOwnerBalance(msg.sender, owner, newCap);
+        }
+        authorizationData[msg.sender][owner][authorized].cap = newCap;
+        emit IncreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
+    }
+
+    function _getDecreasedCap(uint256 currentCap, uint256 subtractedCapRequested) internal pure
+    returns (uint256 newCap, uint256 actualSubtractedCap)
+
+    {
+        if (subtractedCapRequested >= currentCap)
+
+        {
+            // Underflow clips at 0
             newCap = 0;
+            actualSubtractedCap = currentCap;
         }
         else
         {
             unchecked
             {
-                // currentCap >= subtractedCap, no underflow
-                newCap = currentCap - subtractedCap;
+            // currentCap >= subtractedCap, no underflow
+                newCap = currentCap - subtractedCapRequested;
+                actualSubtractedCap = subtractedCapRequested;
             }
         }
+
+    }
+
+    function _decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) internal
+        returns (uint256 newCap, uint256 approvedAmount)
+    {
+        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
+        (newCap, approvedAmount) = _getDecreasedCap(currentCap, subtractedCap);
         authorizationData[msg.sender][owner][authorized].cap = newCap;
         emit DecreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
-        return newCap;
     }
-
 
     function decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) public
+        onlyRegisteredClient
         currentlyAuthorized(msg.sender, owner, authorized)
         validCapAmount(subtractedCap)
-        returns (uint256)
+        returns (uint256 newCap)
     {
-        return _decreaseAuthorizedCap(owner, authorized, subtractedCap);
+        (newCap, ) = _decreaseAuthorizedCap(owner, authorized, subtractedCap);
     }
 
-    function isAuthorized(address addr, address owner, address authorized) public view returns (bool)
+    function isAuthorized(address client, address owner, address authorized) public view returns (bool)
     {
-        return authorizationData[addr][owner][authorized].isAuthorized;
+        return authorizationData[client][owner][authorized].isAuthorized;
     }
 
     function revokeAuthorization(address owner, address authorized) public onlyRegisteredClient
@@ -336,17 +350,19 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         emit RevokeAuthorization(msg.sender, owner, authorized);
     }
 
+    // Approval itself done by client, it is possible to approve on more than owner's current balance, as per ERC20's
+    // approve() method
     function approveFor(address owner, address authorized, address spender, uint256 amount) public
         onlyRegisteredClient
         currentlyAuthorized(msg.sender, owner, authorized)
         validAddress(spender)
+        returns (uint256)
     {
         if ((spender == authorized) || (spender == owner))
         {
             revert InvalidSpender(spender);
         }
-        // ERC20 allows approval > balance, so leave balance check out
-        uint256 currentCap = getAuthorizedCap(msg.sender, owner, authorized);
+        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
         if (currentCap < amount)
         {
             revert InsufficientAuthorizedCap(
@@ -357,8 +373,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
             _decreaseAuthorizedCap(owner, authorized, amount);
         }
         emit ApproveFor(msg.sender, owner, authorized, amount);
-
-        // Approval itself done by client
+        return amount;
     }
 
     /*

--- a/contracts/ERC20AuthorizedClient.sol
+++ b/contracts/ERC20AuthorizedClient.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IERC20Authorized} from "./interfaces/IERC20Authorized.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-abstract contract ERC20AuthorizedClient is IERC20Authorized, ERC20
+abstract contract ERC20AuthorizedClient is ERC20
 {
     // Would be changed once ERC20Authorizer official contract is deployed in Sepolia
     address immutable private authorizationServerAddr;
@@ -47,15 +47,52 @@ abstract contract ERC20AuthorizedClient is IERC20Authorized, ERC20
             address(this), owner, msg.sender);
     }
 
+    function _getIncreasedCap(uint256 currentCap, uint256 addedCapRequested) internal pure
+    returns (uint256 newCap)
+    {
+        unchecked
+        {
+            newCap = currentCap + addedCapRequested;
+            if (newCap < currentCap)
+            {
+                // Overflow occurred
+                newCap = type(uint256).max;
+            }
+        }
+    }
+
     /**
      * @param authorized - existing address authorized by caller
      * @param addedCap - token amount added to existing cap
      */
     function increaseAuthorizedCap(address authorized, uint256 addedCap) public
     {
-        uint256 newCap = IERC20Authorized(authorizationServerAddr).increaseAuthorizedCap(
+        uint256 currentCap = GetAuthorizedCap(authorized);
+        uint256 clientNewCap = _getIncreasedCap(currentCap, addedCap);
+        approve(authorized, clientNewCap);
+        uint256 serverNewCap = IERC20Authorized(authorizationServerAddr).increaseAuthorizedCap(
             msg.sender, authorized, addedCap);
-        approve(authorized, newCap);
+        require(serverNewCap == clientNewCap);
+    }
+
+    function _GetDecreasedCap(uint256 currentCap, uint256 subtractedCapRequested) internal pure
+        returns (uint256 newCap, uint256 actualSubtractedCap)
+    {
+        if (subtractedCapRequested >= currentCap)
+        {
+            // Underflow clips at 0
+            newCap = 0;
+            actualSubtractedCap = currentCap;
+        }
+        else
+        {
+            unchecked
+            {
+            // currentCap >= subtractedCap, no underflow
+                newCap = currentCap - subtractedCapRequested;
+                actualSubtractedCap = subtractedCapRequested;
+            }
+        }
     }
 
     /**
@@ -64,9 +101,12 @@ abstract contract ERC20AuthorizedClient is IERC20Authorized, ERC20
      */
     function decreaseAuthorizedCap(address authorized, uint256 subtractedCap) public
     {
-        uint256 newCap = IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
+        uint256 currentCap = GetAuthorizedCap(authorized);
+        (uint256 clientNewCap, ) = _GetDecreasedCap(currentCap, subtractedCap);
+        approve(authorized, clientNewCap);
+        uint256 serverNewCap = IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
             msg.sender, authorized, subtractedCap);
-        approve(authorized, newCap);
+        require(serverNewCap == clientNewCap);
     }
 
     /**
@@ -108,24 +148,13 @@ abstract contract ERC20AuthorizedClient is IERC20Authorized, ERC20
     function approveFor(address owner, address spender, uint256 amount) public
     {
         uint256 currentCap = GetAuthorizedByCap(owner);
-        uint256 newAuthorizedCap;
-        if (amount >= currentCap)
-        {
-            // Underflow clips at 0
-            newAuthorizedCap = 0;
-        }
-        else
-        {
-            unchecked
-            {
-            // currentCap>=subtractedCap, no way for underflow
-                newAuthorizedCap = currentCap - amount;
-            }
-        }
-        approve(msg.sender, newAuthorizedCap);
-        approve(spender, amount);
-        IERC20Authorized(authorizationServerAddr).approveFor(
+        (uint256 clientNewCap, uint256 clientApprovedAmount) =
+                        _GetDecreasedCap(currentCap, amount);
+        approve(msg.sender, clientNewCap);
+        approve(spender, clientApprovedAmount);
+        uint256 serverApprovedAmount = IERC20Authorized(authorizationServerAddr).approveFor(
             owner, msg.sender, spender, amount);
+        require(serverApprovedAmount == clientApprovedAmount);
     }
 
     /**
@@ -142,6 +171,40 @@ abstract contract ERC20AuthorizedClient is IERC20Authorized, ERC20
             // TODO: consider maybe not revert all if some approvals fail
             IERC20Authorized(authorizationServerAddr).approveFor(
                 owner, msg.sender, spenders[i], amounts[i]);
+        }
+    }
+
+    // TODO: Modify server storage to accommodate this functionality
+    function areAuthorizedByOwner(address owner) internal view returns (address[] memory)
+    {
+        address[] memory authorizers = new address[](1);
+        authorizers[0] = owner;
+        return authorizers;
+    }
+
+
+    function _update(address from, address to, uint256 value) internal virtual override
+    {
+        // Assume balances of 'from'/owner are updated here
+        super._update(from, to, value);
+        if ((from != address(0)) && (to != address(0)))
+        {
+            address[] memory authorizers = areAuthorizedByOwner(from);
+            for (uint256 i = 0; i < authorizers.length; ++i)
+            {
+                if (IERC20Authorized(authorizationServerAddr).isAuthorized(
+                    address(this), from, authorizers[i]))
+                {
+                    uint256 currentCap = IERC20Authorized(authorizationServerAddr).getAuthorizedCap(
+                                            address(this), from, authorizers[i]);
+                    uint256 ownerBalance = balanceOf(from);
+                    if (currentCap > ownerBalance)
+                    {
+                        IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
+                            from, authorizers[i], currentCap - ownerBalance);
+                    }
+                }
+            }
         }
     }
 }

--- a/contracts/interfaces/IERC20Authorized.sol
+++ b/contracts/interfaces/IERC20Authorized.sol
@@ -9,17 +9,17 @@ interface IERC20Authorized is IERC20
     /// Should be called by owner
     function authorize(address owner, address authorized, uint256 cap) external;
 
-    function getAuthorizedCap(address addr, address owner, address authorized) view external returns (uint256);
+    function getAuthorizedCap(address client, address owner, address authorized) view external returns (uint256);
 
     function increaseAuthorizedCap(address owner, address authorized, uint256 addedCap) external returns (uint256);
 
     function decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) external returns (uint256);
 
-    function isAuthorized(address addr, address owner, address authorized) external view returns (bool);
+    function isAuthorized(address client, address owner, address authorized) external view returns (bool);
 
     function revokeAuthorization(address owner, address authorized) external;
 
-    function approveFor(address owner, address authorized, address spender, uint256 amount) external;
+    function approveFor(address owner, address authorized, address spender, uint256 amount) external returns (uint256);
 
     // TODO: Consider moving this functionality to Client
     // Supports approving multiple spenders in a single transaction

--- a/test/DemoClient.sol
+++ b/test/DemoClient.sol
@@ -1,2 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
+
+import {ERC20AuthorizedClient} from "../contracts/ERC20AuthorizedClient.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract DemoClient is ERC20("DemoClient", "DEMO"), ERC20AuthorizedClient
+{
+    constructor(address _authorizationServerAddr) ERC20AuthorizedClient(_authorizationServerAddr) {}
+
+    function _update(address from, address to, uint256 value) internal virtual override(ERC20, ERC20AuthorizedClient)
+    {
+        return super._update(from, to, value);
+    }
+}

--- a/test/ERC20Authorized.t.sol
+++ b/test/ERC20Authorized.t.sol
@@ -273,7 +273,8 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 10, "Cap should updated after authorizing");
         vm.expectEmit(true, true, false, true);
         emit IncreaseAuthorizedCap(address(customToken1), owner, authorized1, 60);
-        erc20Authorized.increaseAuthorizedCap(owner, authorized1, 50);
+        uint256 newCap = erc20Authorized.increaseAuthorizedCap(owner, authorized1, 50);
+        assertEq(newCap, 60, "returned value from increase should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 60, "Cap should updated after increase");
         vm.expectEmit(true, true, false, true);
         emit IncreaseAuthorizedCap(address(customToken1), owner, authorized1, 80);
@@ -281,7 +282,8 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 80, "Cap should updated after increase");
         vm.expectEmit(true, true, false, true);
         emit DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 30);
-        erc20Authorized.decreaseAuthorizedCap(owner, authorized1, 50);
+        newCap = erc20Authorized.decreaseAuthorizedCap(owner, authorized1, 50);
+        assertEq(newCap, 30, "returned value from decrease should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 30, "Cap should updated after decrease");
         vm.expectEmit(true, true, false, true);
         emit DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 20);
@@ -299,7 +301,8 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, 50);
         vm.expectEmit(true, true, false, true);
         emit IncreaseAuthorizedCap(address(customToken1), owner, authorized1, maxInt);
-        erc20Authorized.increaseAuthorizedCap(owner, authorized1, maxInt);
+        uint256 newCap = erc20Authorized.increaseAuthorizedCap(owner, authorized1, maxInt);
+        assertEq(newCap, maxInt, "returned value from increase should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), maxInt, "Cap should clip overflow to maxInt on increase");
     }
 
@@ -311,7 +314,8 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, amount / 2);
         vm.expectEmit(true, true, false, true);
         emit DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 0);
-        erc20Authorized.decreaseAuthorizedCap(owner, authorized1, amount / 2);
+        uint256 newCap = erc20Authorized.decreaseAuthorizedCap(owner, authorized1, amount / 2);
+        assertEq(newCap, 0, "returned value from decrease should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 0, "Cap should decrease");
     }
 


### PR DESCRIPTION
1. Added return values for approveFor, increase, decrease in server. Client uses these return values for assertions.
2. Bugfix for approveFor where `amount>cap` -> The new behavior is that it is allowed and the `newCap = 0` and `approvedAmount = cap`.
3. Client avoids reentrancy with increase/decrease/approveFor becasuse now it calculates the newCap and approving before calling the server.
4. Client _update function first implementation (not tested ) - TBD: allow to fetch list of authorizers given an owner.
5. DemoClient initial implementation that could be connected to testing framework.