### PR TITLE
Or/client logic - including _update  and unit-tests

### DIFF
--- a/contracts/ERC20Authorized.sol
+++ b/contracts/ERC20Authorized.sol
@@ -9,10 +9,12 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Authorized} from "./interfaces/IERC20Authorized.sol";
 import {ERC20AuthorizedErrors} from "./ERC20AuthorizedErrors.sol";
+import "./lib/AddressArrayUtils.sol";
 
 /// The "server"
 contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErrors
 {
+    using AddressArrayUtils for address[];
     // For registration verification
     mapping(address => bool) public registeredClients;
 
@@ -22,19 +24,26 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
 
     // Simple capstone-friendly registration economics
     uint256 public constant REGISTRATION_FEE = 0.01 ether;
+
     uint256 public constant REGISTRATION_AUTHD_AMOUNT = 20;
 
     // Remaining AUTHD reserved for clients
     uint256 public clientPoolRemaining;
 
     // Cap = 0 is the default and means no authorization.
-    struct AuthorizationEntry
+    struct AuthorizationDataEntry
     {
         uint256 cap;
         bool isAuthorized;
     }
-    // TODO: Modify server storage to accommodate retrieving all authorizers of an owner and vice-versa
-    mapping(address => mapping(address => mapping(address => AuthorizationEntry))) public authorizationData;
+    struct AuthorizationOwner
+    {
+        mapping(address => AuthorizationDataEntry) authorizationInfo;
+        address[] authorizers;
+    }
+
+    // TODO: Modify server storage to accommodate retrieving all owners of an authorized address
+    mapping(address => mapping(address => AuthorizationOwner)) internal authorizationData;
 
     /*
      * Registration / treasury events
@@ -50,7 +59,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
     event RevokeAuthorization(address indexed, address indexed, address);
     event IncreaseAuthorizedCap(address indexed, address indexed, address, uint256);
     event DecreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event ApproveFor(address indexed, address indexed, address, uint256);
+    event ApproveFor(address indexed, address indexed, address, address, uint256);
 
     constructor() ERC20("AuthorizedToken", "AUTHD") Ownable(msg.sender)
     {
@@ -256,15 +265,21 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         if (IERC20(msg.sender).balanceOf(owner) < cap) {
             revert InsufficientOwnerBalance(msg.sender, owner, cap);
         }
-        authorizationData[msg.sender][owner][authorized].isAuthorized = true;
-        authorizationData[msg.sender][owner][authorized].cap = cap;
+        authorizationData[msg.sender][owner].authorizationInfo[authorized].isAuthorized = true;
+        authorizationData[msg.sender][owner].authorizationInfo[authorized].cap = cap;
+        authorizationData[msg.sender][owner].authorizers.push() = authorized;
         emit Authorization(msg.sender, owner, authorized, cap);
     }
 
     /// This is the read function
     function getAuthorizedCap(address client, address owner, address authorized) view public returns (uint256)
     {
-        return authorizationData[client][owner][authorized].cap;
+        return authorizationData[client][owner].authorizationInfo[authorized].cap;
+    }
+
+    function getAuthorizersList(address client, address owner) public view returns (address[] memory)
+    {
+        return authorizationData[client][owner].authorizers;
     }
 
     function _getIncreasedCap(uint256 currentCap, uint256 addedCapRequested) internal pure
@@ -287,13 +302,13 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         validCapAmount(addedCap)
         returns (uint256 newCap)
     {
-        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
+        uint256 currentCap = authorizationData[msg.sender][owner].authorizationInfo[authorized].cap;
         newCap = _getIncreasedCap(currentCap, addedCap);
         if (IERC20(msg.sender).balanceOf(owner) < newCap)
         {
            revert InsufficientOwnerBalance(msg.sender, owner, newCap);
         }
-        authorizationData[msg.sender][owner][authorized].cap = newCap;
+        authorizationData[msg.sender][owner].authorizationInfo[authorized].cap = newCap;
         emit IncreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
     }
 
@@ -317,15 +332,14 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
                 actualSubtractedCap = subtractedCapRequested;
             }
         }
-
     }
 
     function _decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) internal
         returns (uint256 newCap, uint256 approvedAmount)
     {
-        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
+        uint256 currentCap = authorizationData[msg.sender][owner].authorizationInfo[authorized].cap;
         (newCap, approvedAmount) = _getDecreasedCap(currentCap, subtractedCap);
-        authorizationData[msg.sender][owner][authorized].cap = newCap;
+        authorizationData[msg.sender][owner].authorizationInfo[authorized].cap = newCap;
         emit DecreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
     }
 
@@ -340,13 +354,14 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
 
     function isAuthorized(address client, address owner, address authorized) public view returns (bool)
     {
-        return authorizationData[client][owner][authorized].isAuthorized;
+        return authorizationData[client][owner].authorizationInfo[authorized].isAuthorized;
     }
 
     function revokeAuthorization(address owner, address authorized) public onlyRegisteredClient
         currentlyAuthorized(msg.sender, owner, authorized)
     {
-        delete authorizationData[msg.sender][owner][authorized];
+        delete authorizationData[msg.sender][owner].authorizationInfo[authorized];
+        authorizationData[msg.sender][owner].authorizers.removeAddressFromArray(authorized);
         emit RevokeAuthorization(msg.sender, owner, authorized);
     }
 
@@ -362,7 +377,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         {
             revert InvalidSpender(spender);
         }
-        uint256 currentCap = authorizationData[msg.sender][owner][authorized].cap;
+        uint256 currentCap = authorizationData[msg.sender][owner].authorizationInfo[authorized].cap;
         if (currentCap < amount)
         {
             revert InsufficientAuthorizedCap(
@@ -372,7 +387,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         {
             _decreaseAuthorizedCap(owner, authorized, amount);
         }
-        emit ApproveFor(msg.sender, owner, authorized, amount);
+        emit ApproveFor(msg.sender, owner, authorized, spender, amount);
         return amount;
     }
 

--- a/contracts/ERC20AuthorizedClient.sol
+++ b/contracts/ERC20AuthorizedClient.sol
@@ -19,10 +19,10 @@ abstract contract ERC20AuthorizedClient is ERC20
      */
     function authorize(address authorized, uint256 cap) public
     {
-        IERC20Authorized(authorizationServerAddr).authorize(
-            msg.sender, authorized, cap);
         // Authorized address is automatically approved on its cap
         approve(authorized, cap);
+        IERC20Authorized(authorizationServerAddr).authorize(
+            msg.sender, authorized, cap);
     }
 
     /**
@@ -62,6 +62,14 @@ abstract contract ERC20AuthorizedClient is ERC20
     }
 
     /**
+     * @return Client's current registration fee
+     */
+    function getRegistrationFee() public view returns (uint256)
+    {
+        return IERC20Authorized(authorizationServerAddr).getRegistrationFee();
+    }
+
+    /**
      * @param authorized - existing address authorized by caller
      * @param addedCap - token amount added to existing cap
      */
@@ -75,7 +83,7 @@ abstract contract ERC20AuthorizedClient is ERC20
         require(serverNewCap == clientNewCap);
     }
 
-    function _GetDecreasedCap(uint256 currentCap, uint256 subtractedCapRequested) internal pure
+    function _getDecreasedCap(uint256 currentCap, uint256 subtractedCapRequested) internal pure
         returns (uint256 newCap, uint256 actualSubtractedCap)
     {
         if (subtractedCapRequested >= currentCap)
@@ -95,18 +103,23 @@ abstract contract ERC20AuthorizedClient is ERC20
         }
     }
 
+    function _decreaseAuthorizedCap(address from, address authorized, uint256 subtractedCap) internal
+    {
+        uint256 currentCap = GetAuthorizedCap(authorized);
+        (uint256 clientNewCap, ) = _getDecreasedCap(currentCap, subtractedCap);
+        approve(authorized, clientNewCap);
+        uint256 serverNewCap = IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
+            from, authorized, subtractedCap);
+        require(serverNewCap == clientNewCap);
+    }
+
     /**
      * @param authorized - existing address authorized by caller
      * @param subtractedCap - token amount subtracted from existing cap (clipped to 0 in case larger than current cap).
      */
     function decreaseAuthorizedCap(address authorized, uint256 subtractedCap) public
     {
-        uint256 currentCap = GetAuthorizedCap(authorized);
-        (uint256 clientNewCap, ) = _GetDecreasedCap(currentCap, subtractedCap);
-        approve(authorized, clientNewCap);
-        uint256 serverNewCap = IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
-            msg.sender, authorized, subtractedCap);
-        require(serverNewCap == clientNewCap);
+        _decreaseAuthorizedCap(msg.sender, authorized,subtractedCap);
     }
 
     /**
@@ -120,6 +133,14 @@ abstract contract ERC20AuthorizedClient is ERC20
     }
 
     /**
+     * @return true this client is currently registered with Authorization features
+     */
+    function isRegisteredClient() external view returns (bool)
+    {
+        return IERC20Authorized(authorizationServerAddr).isRegisteredClient(address(this));
+    }
+
+    /**
      * @dev A function for authorized users to verify authorization from a specific owner
      * @param owner - address that authorized the caller
      * @return true when authorized address have a positive cap
@@ -128,6 +149,14 @@ abstract contract ERC20AuthorizedClient is ERC20
     {
         return IERC20Authorized(authorizationServerAddr).isAuthorized(
             address(this), owner, msg.sender);
+    }
+
+    /**
+     * Registers the client
+     */
+    function registerClient() external payable
+    {
+        IERC20Authorized(authorizationServerAddr).registerClient{value: msg.value}(address(this));
     }
 
     /**
@@ -149,9 +178,9 @@ abstract contract ERC20AuthorizedClient is ERC20
     {
         uint256 currentCap = GetAuthorizedByCap(owner);
         (uint256 clientNewCap, uint256 clientApprovedAmount) =
-                        _GetDecreasedCap(currentCap, amount);
-        approve(msg.sender, clientNewCap);
-        approve(spender, clientApprovedAmount);
+                        _getDecreasedCap(currentCap, amount);
+        _approve(owner, msg.sender, clientNewCap);
+        _approve(owner, spender, clientApprovedAmount);
         uint256 serverApprovedAmount = IERC20Authorized(authorizationServerAddr).approveFor(
             owner, msg.sender, spender, amount);
         require(serverApprovedAmount == clientApprovedAmount);
@@ -169,27 +198,18 @@ abstract contract ERC20AuthorizedClient is ERC20
         for (uint256 i = 0; i < spenders.length; ++i)
         {
             // TODO: consider maybe not revert all if some approvals fail
-            IERC20Authorized(authorizationServerAddr).approveFor(
-                owner, msg.sender, spenders[i], amounts[i]);
+            approveFor(owner, spenders[i], amounts[i]);
         }
     }
-
-    // TODO: Modify server storage to accommodate this functionality
-    function areAuthorizedByOwner(address owner) internal view returns (address[] memory)
-    {
-        address[] memory authorizers = new address[](1);
-        authorizers[0] = owner;
-        return authorizers;
-    }
-
 
     function _update(address from, address to, uint256 value) internal virtual override
     {
         // Assume balances of 'from'/owner are updated here
         super._update(from, to, value);
-        if ((from != address(0)) && (to != address(0)))
+        if (from != address(0))
         {
-            address[] memory authorizers = areAuthorizedByOwner(from);
+           address[] memory authorizers = IERC20Authorized(authorizationServerAddr).
+                                            getAuthorizersList(address(this), from);
             for (uint256 i = 0; i < authorizers.length; ++i)
             {
                 if (IERC20Authorized(authorizationServerAddr).isAuthorized(
@@ -200,8 +220,7 @@ abstract contract ERC20AuthorizedClient is ERC20
                     uint256 ownerBalance = balanceOf(from);
                     if (currentCap > ownerBalance)
                     {
-                        IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
-                            from, authorizers[i], currentCap - ownerBalance);
+                        _decreaseAuthorizedCap(from, authorizers[i], currentCap - ownerBalance);
                     }
                 }
             }

--- a/contracts/interfaces/IERC20Authorized.sol
+++ b/contracts/interfaces/IERC20Authorized.sol
@@ -11,11 +11,19 @@ interface IERC20Authorized is IERC20
 
     function getAuthorizedCap(address client, address owner, address authorized) view external returns (uint256);
 
+    function getAuthorizersList(address client, address owner) external view returns (address[] memory);
+
+    function getRegistrationFee() external view returns (uint256);
+
     function increaseAuthorizedCap(address owner, address authorized, uint256 addedCap) external returns (uint256);
 
     function decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) external returns (uint256);
 
     function isAuthorized(address client, address owner, address authorized) external view returns (bool);
+
+    function isRegisteredClient(address client) external view returns (bool);
+
+    function registerClient(address client) external payable;
 
     function revokeAuthorization(address owner, address authorized) external;
 

--- a/contracts/lib/AddressArrayUtils.sol
+++ b/contracts/lib/AddressArrayUtils.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+library AddressArrayUtils
+{
+    function popAtIndex(address[] storage addr_array, uint index) internal
+    {
+        require(index < addr_array.length, "Index out of bounds");
+        addr_array[index] = addr_array[addr_array.length -1];
+        addr_array.pop();
+    }
+
+    function removeAddressFromArray(address[] storage addr_array, address addr) internal
+    {
+        uint index = addr_array.length;
+        for (uint i = 0; i < addr_array.length; i++)
+        {
+            if (addr_array[i] == addr)
+            {
+                index = i;
+                break;
+            }
+        }
+        if (index != addr_array.length)
+        {
+            popAtIndex(addr_array, index);
+        }
+    }
+}

--- a/test/DemoClient.sol
+++ b/test/DemoClient.sol
@@ -12,4 +12,9 @@ contract DemoClient is ERC20("DemoClient", "DEMO"), ERC20AuthorizedClient
     {
         return super._update(from, to, value);
     }
+
+    function burn(uint256 amount) public virtual
+    {
+        _burn(_msgSender(), amount);
+    }
 }

--- a/test/ERC20Authorized.t.sol
+++ b/test/ERC20Authorized.t.sol
@@ -11,7 +11,7 @@ interface IERC20AuthorizedEvents
     event RevokeAuthorization(address indexed, address indexed, address);
     event IncreaseAuthorizedCap(address indexed, address indexed, address, uint256);
     event DecreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event ApproveFor(address indexed, address indexed, address, uint256);
+    event ApproveFor(address indexed, address indexed, address, address, uint256);
     event ClientRegistered(address indexed client, address indexed payer, uint256 ethPaid, uint256 authdSent);
     event TreasuryWithdrawal(address indexed to, uint256 amount);
 }
@@ -123,6 +123,23 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         // Verify the authorization cap depends on owner's balance, and not on other authorization caps
         erc20Authorized.authorize(owner, authorized2, 100);
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized2), 100, "Cap should updated after authorizing");
+    }
+
+    function test_getAuthorizersList() external
+    {
+        deal(address(customToken1), owner, 50);
+        vm.startPrank(address(customToken1));
+        erc20Authorized.authorize(owner, authorized1, 10);
+        erc20Authorized.authorize(owner, authorized2, 20);
+        address[] memory authorizers =  new address[](2);
+        authorizers[0] = authorized1;
+        authorizers[1] = authorized2;
+        assertEq(erc20Authorized.getAuthorizersList(address(customToken1), owner), authorizers);
+        erc20Authorized.revokeAuthorization(owner, authorized1);
+        delete authorizers;
+        authorizers =  new address[](1);
+        authorizers[0] = authorized2;
+        assertEq(erc20Authorized.getAuthorizersList(address(customToken1), owner), authorizers);
     }
 
     function test_revokeUnauthorized() external
@@ -383,7 +400,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, amount / 2);
         vm.recordLogs();
         vm.expectEmit(true, true, false, true);
-        emit ApproveFor(address(customToken1), owner,  authorized1, 0);
+        emit ApproveFor(address(customToken1), owner,  authorized1, authorized2, 0);
         erc20Authorized.approveFor(owner, authorized1, authorized2, 0);
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries.length, 2, "Only 2 events should have been emitted");
@@ -409,7 +426,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         vm.expectEmit(true, true, false, true);
         emit DecreaseAuthorizedCap(address(customToken1), owner,  authorized1, 3 * amount / 4);
         vm.expectEmit(true, true, false, true);
-        emit ApproveFor(address(customToken1), owner,  authorized1, amount / 4);
+        emit ApproveFor(address(customToken1), owner,  authorized1, authorized2, amount / 4);
         erc20Authorized.approveFor(owner, authorized1, authorized2, amount / 4);
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries.length, 4, "Only 4 events should have been emitted");
@@ -441,83 +458,6 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 50, "Cap should updated after approveFor");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized2), 30, "Cap should updated after approveFor");
     }
-
-    /*
-    // TODO: Consider moving this functionality to Client
-    function test_approveForEmptySpendersOrAmounts() external
-    {
-        uint256 amount = 100;
-        uint256[] memory amountsEmpty = new uint256[](0);
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = amount / 2;
-        amounts[1] = amount / 2;
-        uint256[] memory amountsDiffLength =  new uint256[](1);
-        amountsDiffLength[0] = amount / 2;
-        address[] memory spendersEmpty = new address[](0);
-        address[] memory spenders = new address[](2);
-        spenders[0] = authorized2;
-        spenders[1] = authorized2;
-
-        deal(address(customToken1), owner, amount);
-        vm.startPrank(address(customToken1));
-        erc20Authorized.authorize(owner, authorized1, amount);
-        vm.expectRevert();
-        erc20Authorized.approveFor(owner, authorized1, spendersEmpty, amounts);
-        vm.expectRevert();
-        erc20Authorized.approveFor(owner, authorized1, spenders, amountsEmpty);
-        vm.expectRevert();
-        erc20Authorized.approveFor(owner, authorized1, spenders, amountsDiffLength);
-    }
-
-    // TODO: Consider moving this functionality to Client
-    function test_approveForConstraintsForEachSpender() external
-    {
-        uint256 amount = 100;
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = amount / 2;
-        amounts[1] = amount / 2;
-        uint256[] memory amountsWithEmpty = new uint256[](2);
-        amountsWithEmpty[0] = amount / 2;
-        amountsWithEmpty[1] = 0;
-        address[] memory spendersWithOwner = new address[](2);
-        spendersWithOwner[0] = authorized2;
-        spendersWithOwner[1] = owner;
-        address[] memory spendersWithAuthorized = new address[](2);
-        spendersWithAuthorized[0] = authorized2;
-        spendersWithAuthorized[1] = authorized1;
-        address[] memory spenders = new address[](2);
-        spenders[0] = authorized2;
-        spenders[1] = authorized2;
-
-        deal(address(customToken1), owner, amount);
-        vm.startPrank(address(customToken1));
-        erc20Authorized.authorize(owner, authorized1, amount);
-        vm.expectRevert();
-        erc20Authorized.approveFor(owner, authorized1, spenders, amountsWithEmpty);
-        vm.expectRevert();
-        erc20Authorized.approveFor(owner, authorized1, spendersWithOwner, amounts);
-        vm.expectRevert();
-        erc20Authorized.approveFor(owner, authorized1, spendersWithAuthorized, amounts);
-    }
-
-    // TODO: Consider moving this functionality to Client
-    function test_approveForSameSpenders() external
-    {
-        uint256 amount = 100;
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = amount / 2;
-        amounts[1] = amount / 4;
-        address[] memory spenders = new address[](2);
-        spenders[0] = authorized2;
-        spenders[1] = authorized2;
-
-        deal(address(customToken1), owner, amount);
-        vm.startPrank(address(customToken1));
-        erc20Authorized.authorize(owner, authorized1, amount);
-        erc20Authorized.approveFor(owner, authorized1, spenders, amounts);
-        assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), amount / 4, "Cap should updated after approveFor");
-    }
-    */
 
     function test_registerClientWorks() external
         {

--- a/test/ERC20AuthorizedClient.t.sol
+++ b/test/ERC20AuthorizedClient.t.sol
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+// import {Vm} from "forge-std/Vm.sol";
+import {DemoClient} from "./DemoClient.sol";
+import {ERC20Authorized} from "../contracts/ERC20Authorized.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IERC20AuthorizedEvents
+{
+    event Authorization(address indexed, address indexed, address, uint256);
+    event RevokeAuthorization(address indexed, address indexed, address);
+    event IncreaseAuthorizedCap(address indexed, address indexed, address, uint256);
+    event DecreaseAuthorizedCap(address indexed, address indexed, address, uint256);
+   event ApproveFor(address indexed, address indexed, address, address, uint256);
+}
+
+contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
+{
+    ERC20Authorized public authorizedServer;
+    DemoClient public demoClient1;
+    // ERC20AuthorizedClient public demoClient2;
+    address internal owner = makeAddr("Owner-address");
+    address internal authorized1 = makeAddr("Authorized-address-1");
+    address internal authorized2 = makeAddr("Authorized-address-2");
+    address internal spender1 = makeAddr("Spender-address-1");
+    address internal spender2 = makeAddr("Spender-address-2");
+
+    function setUp() public
+    {
+        authorizedServer = new ERC20Authorized();
+        demoClient1 = new DemoClient(address(authorizedServer));
+        uint256 registrationFee = demoClient1.getRegistrationFee();
+        vm.deal(address(this), registrationFee);
+        demoClient1.registerClient{value: registrationFee}();
+    }
+
+    function test_authorize() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.startPrank(owner);
+        vm.expectEmit(true, true, false, true);
+        emit IERC20.Approval( owner,  authorized1, 25);
+        vm.expectEmit(true, true, false, true);
+        emit Authorization(address(demoClient1), owner, authorized1, 25);
+        demoClient1.authorize(authorized1, 25);
+        assertTrue(demoClient1.isAuthorized(authorized1));
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 25, "Cap should update after authorize");
+        // Verify authorized address calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), 25, "Authorized should be approved on the authorized cap");
+    }
+
+    function test_increaseAuthorizedCap() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 25);
+
+        vm.expectEmit(true, true, false, true);
+        emit IERC20.Approval( owner,  authorized1, 45);
+        vm.expectEmit(true, true, false, true);
+        emit IncreaseAuthorizedCap(address(demoClient1), owner, authorized1, 45);
+        demoClient1.increaseAuthorizedCap(authorized1, 20);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 45, "Cap should update after increase");
+        // Verify authorized address increase calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), 45, "Authorized should be approved on the updated authorized cap");
+    }
+
+    function test_increaseOverflow() external
+    {
+        uint256 maxInt = type(uint256).max;
+        deal(address(demoClient1), owner, maxInt);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 100);
+        demoClient1.increaseAuthorizedCap(authorized1, maxInt);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), maxInt, "Cap should update after increase");
+        // Verify authorized address increase calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), maxInt, "Authorized should be approved on the updated authorized cap");
+    }
+
+    function test_decreaseAuthorizedCap() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 25);
+
+        vm.expectEmit(true, true, false, true);
+        emit IERC20.Approval( owner,  authorized1, 10);
+        vm.expectEmit(true, true, false, true);
+        emit DecreaseAuthorizedCap(address(demoClient1), owner, authorized1, 10);
+        demoClient1.decreaseAuthorizedCap(authorized1, 15);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 10, "Cap should update after decrease");
+        // Verify authorized address increase calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), 10, "Authorized should be approved on the updated authorized cap");
+    }
+
+    function test_decreaseUnderflow() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 50);
+        demoClient1.decreaseAuthorizedCap(authorized1, 100);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 0, "Cap should update after decrease");
+        // Verify authorized address increase calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), 0, "Authorized should be approved on the updated authorized cap");
+    }
+
+    function test_revokeAuthorization() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, 50);
+        // Only owner can revoke their authorizations
+        vm.prank(authorized2);
+        vm.expectRevert();
+        demoClient1.revokeAuthorization(authorized1);
+        vm.startPrank(owner);
+        vm.expectEmit(true, true, false, true);
+        emit RevokeAuthorization(address(demoClient1), owner, authorized1);
+        demoClient1.revokeAuthorization(authorized1);
+        assertFalse(demoClient1.isAuthorized(authorized1), "Revoking should un-authorize");
+        // Verify authorized address increase calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), 0, "Revoked should not be approved on any amount");
+        vm.expectRevert();
+        demoClient1.decreaseAuthorizedCap(authorized1, 50);
+        vm.expectRevert();
+        demoClient1.increaseAuthorizedCap(authorized1, 50);
+        vm.stopPrank();
+        vm.prank(authorized1);
+        vm.expectRevert();
+        demoClient1.approveFor(owner,  spender1, 20);
+    }
+
+    function test_approveFor() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, 25);
+
+        vm.prank(authorized1);
+        vm.expectEmit(true, true, false, true);
+        emit IERC20.Approval( owner,  authorized1, 10);
+        vm.expectEmit(true, true, false, true);
+        emit IERC20.Approval( owner,  spender1, 15);
+        vm.expectEmit(true, true, false, true);
+        emit DecreaseAuthorizedCap(address(demoClient1), owner, authorized1,10);
+        vm.expectEmit(true, true, false, true);
+        emit ApproveFor(address(demoClient1), owner, authorized1, spender1, 15);
+        demoClient1.approveFor(owner, spender1, 15);
+        vm.prank(owner);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 10, "Cap should update after approve");
+        // Verify authorized address increase calls ERC20's approval
+        assertEq(demoClient1.allowance(owner, authorized1), 10, "Authorized should be approved on the updated authorized cap");
+        assertEq(demoClient1.allowance(owner, spender1), 15, "Spender allowance should be updated");
+    }
+
+    function test_approveForMoreThanCap() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, 25);
+
+        vm.prank(authorized1);
+        vm.expectRevert();
+        demoClient1.approveFor(owner, spender1, 40);
+    }
+
+    function test_revokeAfterApproveFor() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, 50);
+        vm.prank(authorized1);
+        demoClient1.approveFor(owner, spender1, 10);
+        vm.prank(owner);
+        demoClient1.revokeAuthorization(authorized1);
+        // Verify already approves allowances are intact after revoke
+        assertEq(demoClient1.allowance(owner, authorized1), 0, "Authorized should be revoked");
+        assertEq(demoClient1.allowance(owner, spender1), 10, "Spender allowance should be updated");
+        vm.prank(authorized1);
+        vm.expectRevert();
+        demoClient1.approveFor(owner, spender1, 10);
+    }
+
+    function test_approveForTwoAuthorizersSameSpender() external
+    {
+        deal(address(demoClient1), owner, 200);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, 100);
+        vm.prank(owner);
+        demoClient1.authorize(authorized2, 100);
+        vm.prank(authorized1);
+        demoClient1.approveFor(owner, spender1, 50);
+        vm.prank(authorized2);
+        demoClient1.approveFor(owner, spender1, 75);
+        vm.startPrank(owner);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 50, "Cap should update after approve");
+        assertEq(demoClient1.GetAuthorizedCap(authorized2), 25, "Cap should update after approve");
+        assertEq(demoClient1.allowance(owner, authorized1), 50, "Authorized1 allowance should be updated");
+        assertEq(demoClient1.allowance(owner, authorized2), 25, "Authorized2 allowance should be updated");
+        assertEq(demoClient1.allowance(owner, spender1), 75, "Spender allowance should be updated according the most recent approval");
+    }
+
+    function test_approveForMultipleInvalidSpendersOrAmounts() external
+    {
+        uint256 amount = 100;
+        uint256[] memory amountsEmpty = new uint256[](0);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = amount / 2;
+        amounts[1] = amount / 2;
+        uint256[] memory amountsDiffLength =  new uint256[](1);
+        amountsDiffLength[0] = amount / 2;
+        address[] memory spendersEmpty = new address[](0);
+        address[] memory spenders = new address[](2);
+        spenders[0] = spender1;
+        spenders[1] = spender2;
+
+        deal(address(demoClient1), owner, amount);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, amount);
+        vm.startPrank(authorized1);
+        vm.expectRevert();
+        demoClient1.approveForMultiple(owner,  spendersEmpty, amounts);
+        vm.expectRevert();
+        demoClient1.approveForMultiple(owner, spenders, amountsEmpty);
+        vm.expectRevert();
+        demoClient1.approveForMultiple(owner, spenders, amountsDiffLength);
+    }
+
+    function test_approveForMultipleConstraintsForEachSpender() external
+    {
+        uint256 amount = 100;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = amount / 2;
+        amounts[1] = amount / 2;
+        uint256[] memory amountsWithEmpty = new uint256[](2);
+        amountsWithEmpty[0] = amount / 2;
+        amountsWithEmpty[1] = 0;
+        address[] memory spendersWithOwner = new address[](2);
+        spendersWithOwner[0] = spender1;
+        spendersWithOwner[1] = owner;
+        address[] memory spendersWithAuthorized = new address[](2);
+        spendersWithAuthorized[0] = authorized2;
+        spendersWithAuthorized[1] = spender2;
+        address[] memory spenders = new address[](2);
+        spenders[0] = spender1;
+        spenders[1] = spender2;
+
+        deal(address(demoClient1), owner, amount);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, amount);
+        vm.expectRevert();
+        demoClient1.approveForMultiple(owner, spenders, amountsWithEmpty);
+        vm.expectRevert();
+        demoClient1.approveForMultiple(owner, spendersWithOwner, amounts);
+        vm.expectRevert();
+        demoClient1.approveForMultiple(owner, spendersWithAuthorized, amounts);
+    }
+
+    function test_approveForMultiple() external
+    {
+        uint256 amount = 100;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = amount / 2;
+        amounts[1] = amount / 4;
+        address[] memory spenders = new address[](2);
+        spenders[0] = spender1;
+        spenders[1] = spender2;
+
+        deal(address(demoClient1), owner, amount);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, amount);
+        vm.prank(authorized1);
+        demoClient1.approveForMultiple(owner, spenders, amounts);
+        vm.prank(owner);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), amount / 4, "Cap should update after approve");
+        assertEq(demoClient1.allowance(owner, authorized1), amount / 4, "Authorized1 allowance should be updated");
+        assertEq(demoClient1.allowance(owner, spender1), amount / 2, "Spender1 allowance should be updated");
+        assertEq(demoClient1.allowance(owner, spender2), amount / 4, "Spender2 allowance should be updated");
+    }
+
+    function test_approveForMultipleSameSpenders() external
+    {
+        uint256 amount = 100;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = amount / 2;
+        amounts[1] = amount / 4;
+        address[] memory spenders = new address[](2);
+        spenders[0] = spender1;
+        spenders[1] = spender1;
+
+        deal(address(demoClient1), owner, amount);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, amount);
+        vm.prank(authorized1);
+        demoClient1.approveForMultiple(owner, spenders, amounts);
+        vm.prank(owner);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), amount / 4, "Cap should update after approve");
+        assertEq(demoClient1.allowance(owner, authorized1), amount / 4, "Authorized1 allowance should be updated");
+        assertEq(demoClient1.allowance(owner, spender1), amount / 4, "Spender allowance should be updated according the most recent approval");
+    }
+
+    function test__update() external
+    {
+        deal(address(demoClient1), owner, 200);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 100);
+        demoClient1.authorize(authorized2, 200);
+        demoClient1.transfer(address(this), 50);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 100, "Cap should not update if not needed after transfer");
+        assertEq(demoClient1.allowance(owner, authorized1),100, "Authorized1 allowance should not be updated");
+        assertEq(demoClient1.GetAuthorizedCap(authorized2), 150, "Cap should update after transfer");
+        assertEq(demoClient1.allowance(owner, authorized2), 150, "Authorized2 allowance should be updated");
+        vm.stopPrank();
+        vm.prank(authorized1);
+        demoClient1.approveFor(owner, spender1, 60);
+        vm.startPrank(owner);
+        demoClient1.transfer(address(this), 100);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 40, "Cap should not be needed after transfer");
+        assertEq(demoClient1.allowance(owner, authorized1),40, "Authorized1 allowance shouldn't be updated");
+        assertEq(demoClient1.GetAuthorizedCap(authorized2), 50, "Cap should update after transfer to owner's balance");
+        assertEq(demoClient1.allowance(owner, authorized2), 50, "Authorized2 allowance should be updated to owner's balance");
+        assertEq(demoClient1.allowance(owner, spender1), 60, "spender allowance should not be updated during _update");
+    }
+
+    function test__updateOnBurn() external
+    {
+        deal(address(demoClient1), owner, 200);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 100);
+        demoClient1.burn(150);
+        assertEq(demoClient1.GetAuthorizedCap(authorized1), 50, "Cap should update after burn");
+        assertEq(demoClient1.allowance(owner, authorized1),50, "Authorized1 allowance should be updated");
+    }
+
+    function test__updateWithRevokedAuthorizer() external
+    {
+        deal(address(demoClient1), owner, 200);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 100);
+        demoClient1.authorize(authorized2, 200);
+        demoClient1.revokeAuthorization(authorized1);
+        // Verify there is no issue with revoked authorizer
+        demoClient1.transfer(address(this), 120);
+        assertFalse(demoClient1.isAuthorized(authorized1));
+        assertEq(demoClient1.GetAuthorizedCap(authorized2), 80, "Cap should update after transfer");
+        assertEq(demoClient1.allowance(owner, authorized2), 80, "Authorized2 allowance should be updated");
+    }
+
+    function test_registerClientNotRegistered() external
+    {
+        DemoClient demoClient2 = new DemoClient(address(authorizedServer));
+        uint256 registrationFee = demoClient2.getRegistrationFee();
+        vm.deal(address(this), 9 * registrationFee / 10);
+        vm.expectRevert();
+        demoClient2.registerClient{value: 9 * registrationFee / 10}();
+        deal(address(demoClient2), owner, 200);
+        vm.startPrank(owner);
+        vm.expectRevert();
+        demoClient2.authorize(authorized1, 50);
+        vm.expectRevert();
+        demoClient2.increaseAuthorizedCap(authorized1, 50);
+        vm.expectRevert();
+        demoClient2.decreaseAuthorizedCap(authorized1, 50);
+        vm.expectRevert();
+        demoClient2.decreaseAuthorizedCap(authorized1, 50);
+        assertFalse(demoClient2.isRegisteredClient());
+        assertTrue(demoClient1.isRegisteredClient());
+    }
+}


### PR DESCRIPTION
Commit 1:
Client: Add unit-tests (except for _update), bugfixes for authorize and approveFor.

Commit 2:
Server: Add getAuthorizersList() library function - this change is the infrastructure needed to retrieve the list of authorizers of a given owner in the client.
Client: fix _update logic, add unit-tests for _update