### PR TITLE
Finalize client-server interfaces 

### DIFF
--- a/contracts/ERC20Authorized.sol
+++ b/contracts/ERC20Authorized.sol
@@ -16,21 +16,20 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
 {
     using AddressArrayUtils for address[];
     // For registration verification
-    mapping(address => bool) public registeredClients;
+    mapping(address => bool) public isRegisteredClient;
 
-    uint256 private constant INITIAL_AUTHD_SUPPLY = 1_000_000;
+    uint256 internal constant INITIAL_AUTHD_SUPPLY = 1_000_000;
     // 25% of total supply reserved for client registrations
-    uint256 public constant CLIENT_AUTHD_POOL = 250_000;
+    uint256 internal constant CLIENT_AUTHD_POOL = 250_000;
 
     // Simple capstone-friendly registration economics
-    uint256 public constant REGISTRATION_FEE = 0.01 ether;
+    uint256 internal constant REGISTRATION_FEE = 0.01 ether;
 
     uint256 public constant REGISTRATION_AUTHD_AMOUNT = 20;
 
     // Remaining AUTHD reserved for clients
-    uint256 public clientPoolRemaining;
+    uint256 internal clientPoolRemaining;
 
-    // Cap = 0 is the default and means no authorization.
     struct AuthorizationDataEntry
     {
         uint256 cap;
@@ -41,25 +40,13 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         mapping(address => AuthorizationDataEntry) authorizationInfo;
         address[] authorizers;
     }
+    struct AuthorizationClient
+    {
+        mapping(address => AuthorizationOwner) authorizationOwner;
+        mapping (address => address[]) delegatedBy;
+    }
 
-    // TODO: Modify server storage to accommodate retrieving all owners of an authorized address
-    mapping(address => mapping(address => AuthorizationOwner)) internal authorizationData;
-
-    /*
-     * Registration / treasury events
-     */
-    event ClientRegistered(address indexed client, address indexed payer, uint256 ethPaid, uint256 authdSent);
-    event ClientRegistrationRevoked(address indexed client);
-    event TreasuryWithdrawal(address indexed to, uint256 amount);
-
-    /*
-     * INTERFACE / AUTHORIZATION EVENTS
-     */
-    event Authorization(address indexed, address indexed, address, uint256);
-    event RevokeAuthorization(address indexed, address indexed, address);
-    event IncreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event DecreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event ApproveFor(address indexed, address indexed, address, address, uint256);
+    mapping(address => AuthorizationClient) internal authorizationData;
 
     constructor() ERC20("AuthorizedToken", "AUTHD") Ownable(msg.sender)
     {
@@ -80,13 +67,11 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
 
     modifier onlyRegisteredClient()
     {
-        require(registeredClients[msg.sender], "Client contract not registered");
+        if (!isRegisteredClient[msg.sender])
+        {
+            revert ClientNotRegistered(msg.sender);
+        }
         _;
-    }
-
-    function isRegisteredClient(address client) public view returns (bool)
-    {
-        return registeredClients[client];
     }
 
     function _linearRate(uint256 x, uint256 xHigh, uint256 xLow, uint256 yHigh, uint256 yLow) internal pure returns (uint256) {
@@ -96,8 +81,6 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         // y = yHigh + (xHigh - x) * (yLow - yHigh) / (xHigh - xLow)
         return yHigh + ((xHigh - x) * (yLow - yHigh)) / (xHigh - xLow);
     }
-
-
 
     /**
      * Piecewise linear pricing preview.
@@ -109,7 +92,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
      * Tier 2: 200000 ->  50000 maps 0.0004 ETH -> 0.002 ETH
      * Tier 3:  50000 ->      0 maps 0.002 ETH -> 0.01 ETH
      */
-    function previewAuthdRate(uint256 remainingWholeTokens) public pure returns (uint256) {
+    function previewAuthdRate(uint256 remainingWholeTokens) internal pure returns (uint256) {
         if (remainingWholeTokens >= 200_000) {
             return _linearRate(
                 remainingWholeTokens,
@@ -142,7 +125,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
     /**
      * Current ETH price per 1 AUTHD token (1 whole token, not 1 wei of AUTHD).
      */
-    function getAuthdRate() public view returns (uint256) {
+    function getAuthdRate() internal view returns (uint256) {
         uint256 remainingWholeTokens = clientPoolRemaining / 1e18;
         return previewAuthdRate(remainingWholeTokens);
     }
@@ -160,7 +143,6 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         return dynamicFee;
     }
 
-
     /**
      * Register a client token contract so it can use the AUTHD authorization logic.
      *
@@ -171,23 +153,33 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
      */
     /**
      * Register a client token contract.
-     * The caller pays ETH according to the current rate and the client receives 20 AUTHD.
+     * The caller (client) pays ETH according to the current rate and receives back AUTHD tokens
      */
-    function registerClient(address client) external payable {
-        require(client != address(0), "Invalid client address");
-        require(!registeredClients[client], "Client already registered");
-
+    function registerClient() public payable validAddress(msg.sender) {
+        address client = msg.sender;
+        if (isRegisteredClient[client])
+        {
+            revert AlreadyRegistered(client);
+        }
         uint256 fee = getRegistrationFee();
-        require(msg.value >= fee, "Insufficient registration fee");
-        require(clientPoolRemaining >= REGISTRATION_AUTHD_AMOUNT, "Client pool exhausted");
-        require(balanceOf(address(this)) >= REGISTRATION_AUTHD_AMOUNT, "Insufficient AUTHD in pool");
-        // TODO: use custom errors instead of `require` to reduce code size
-        registeredClients[client] = true;
+        if (msg.value < fee)
+        {
+            revert InsufficientRegistrationFee(msg.value, fee);
+        }
+        if (clientPoolRemaining < REGISTRATION_AUTHD_AMOUNT)
+        {
+            revert ClientPoolExhuasted(clientPoolRemaining, REGISTRATION_AUTHD_AMOUNT);
+        }
+        if (balanceOf(address(this)) < REGISTRATION_AUTHD_AMOUNT)
+        {
+            revert InsufficientAuthdSupply(balanceOf(address(this)), REGISTRATION_AUTHD_AMOUNT);
+        }
+        isRegisteredClient[client] = true;
         clientPoolRemaining -= REGISTRATION_AUTHD_AMOUNT;
 
         _transfer(address(this), client, REGISTRATION_AUTHD_AMOUNT);
 
-        emit ClientRegistered(client, msg.sender, msg.value, REGISTRATION_AUTHD_AMOUNT);
+        emit ClientRegistered(client, msg.value, REGISTRATION_AUTHD_AMOUNT);
     }
 
     /**
@@ -195,18 +187,20 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
      */
     function revokeClientRegistration(address client) external onlyOwner
     {
-        require(registeredClients[client], "Client not registered");
-        registeredClients[client] = false;
+        if (!isRegisteredClient[client])
+        {
+            revert ClientNotRegistered(client);
+        }
+        isRegisteredClient[client] = false;
+        delete authorizationData[client];
         emit ClientRegistrationRevoked(client);
     }
 
     /**
      * Withdraw ETH accumulated from client registrations.
      */
-    function withdrawTreasury(address payable to) external onlyOwner
+    function withdrawTreasury(address payable to) external onlyOwner validAddress(to)
     {
-        require(to != address(0), "Invalid withdraw address");
-
         uint256 amount = address(this).balance;
         require(amount > 0, "No ETH to withdraw");
         (bool ok, ) = to.call{value: amount}("");
@@ -219,7 +213,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
 
     /*
      * -----------------------------
-     * Existing authorization logic
+     * Authorization server-side logic
      * -----------------------------
      */
 
@@ -247,9 +241,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         _;
     }
 
-    /// authorize docstring - assuming msg.sender is the registered token contract
     function authorize(address owner, address authorized, uint256 cap) public
-       
         onlyRegisteredClient
         validAddress(owner)
         validAddress(authorized)
@@ -265,21 +257,26 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         if (IERC20(msg.sender).balanceOf(owner) < cap) {
             revert InsufficientOwnerBalance(msg.sender, owner, cap);
         }
-        authorizationData[msg.sender][owner].authorizationInfo[authorized].isAuthorized = true;
-        authorizationData[msg.sender][owner].authorizationInfo[authorized].cap = cap;
-        authorizationData[msg.sender][owner].authorizers.push() = authorized;
+        authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].isAuthorized = true;
+        authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].cap = cap;
+        authorizationData[msg.sender].authorizationOwner[owner].authorizers.push() = authorized;
+        authorizationData[msg.sender].delegatedBy[authorized].push() = owner;
         emit Authorization(msg.sender, owner, authorized, cap);
     }
 
-    /// This is the read function
     function getAuthorizedCap(address client, address owner, address authorized) view public returns (uint256)
     {
-        return authorizationData[client][owner].authorizationInfo[authorized].cap;
+        return authorizationData[client].authorizationOwner[owner].authorizationInfo[authorized].cap;
     }
 
     function getAuthorizersList(address client, address owner) public view returns (address[] memory)
     {
-        return authorizationData[client][owner].authorizers;
+        return authorizationData[client].authorizationOwner[owner].authorizers;
+    }
+
+    function getOwnersList(address client, address authorized) public view returns (address[] memory)
+    {
+        return authorizationData[client].delegatedBy[authorized];
     }
 
     function _getIncreasedCap(uint256 currentCap, uint256 addedCapRequested) internal pure
@@ -302,13 +299,13 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         validCapAmount(addedCap)
         returns (uint256 newCap)
     {
-        uint256 currentCap = authorizationData[msg.sender][owner].authorizationInfo[authorized].cap;
+        uint256 currentCap = authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].cap;
         newCap = _getIncreasedCap(currentCap, addedCap);
         if (IERC20(msg.sender).balanceOf(owner) < newCap)
         {
            revert InsufficientOwnerBalance(msg.sender, owner, newCap);
         }
-        authorizationData[msg.sender][owner].authorizationInfo[authorized].cap = newCap;
+        authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].cap = newCap;
         emit IncreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
     }
 
@@ -337,9 +334,9 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
     function _decreaseAuthorizedCap(address owner, address authorized, uint256 subtractedCap) internal
         returns (uint256 newCap, uint256 approvedAmount)
     {
-        uint256 currentCap = authorizationData[msg.sender][owner].authorizationInfo[authorized].cap;
+        uint256 currentCap = authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].cap;
         (newCap, approvedAmount) = _getDecreasedCap(currentCap, subtractedCap);
-        authorizationData[msg.sender][owner].authorizationInfo[authorized].cap = newCap;
+        authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].cap = newCap;
         emit DecreaseAuthorizedCap(msg.sender, owner, authorized, newCap);
     }
 
@@ -354,14 +351,15 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
 
     function isAuthorized(address client, address owner, address authorized) public view returns (bool)
     {
-        return authorizationData[client][owner].authorizationInfo[authorized].isAuthorized;
+        return authorizationData[client].authorizationOwner[owner].authorizationInfo[authorized].isAuthorized;
     }
 
     function revokeAuthorization(address owner, address authorized) public onlyRegisteredClient
         currentlyAuthorized(msg.sender, owner, authorized)
     {
-        delete authorizationData[msg.sender][owner].authorizationInfo[authorized];
-        authorizationData[msg.sender][owner].authorizers.removeAddressFromArray(authorized);
+        delete authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized];
+        authorizationData[msg.sender].authorizationOwner[owner].authorizers.removeAddressFromArray(authorized);
+        authorizationData[msg.sender].delegatedBy[authorized].removeAddressFromArray(owner);
         emit RevokeAuthorization(msg.sender, owner, authorized);
     }
 
@@ -377,7 +375,7 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         {
             revert InvalidSpender(spender);
         }
-        uint256 currentCap = authorizationData[msg.sender][owner].authorizationInfo[authorized].cap;
+        uint256 currentCap = authorizationData[msg.sender].authorizationOwner[owner].authorizationInfo[authorized].cap;
         if (currentCap < amount)
         {
             revert InsufficientAuthorizedCap(
@@ -390,17 +388,4 @@ contract ERC20Authorized is ERC20, Ownable, IERC20Authorized, ERC20AuthorizedErr
         emit ApproveFor(msg.sender, owner, authorized, spender, amount);
         return amount;
     }
-
-    /*
-    // TODO: Consider moving this functionality to Client
-    // Supports approving multiple spenders in a single transaction
-    function approveFor(address owner, address authorized, address[] calldata spenders, uint256[] calldata amounts) public
-    {
-        require((spenders.length == amounts.length) && (amounts.length > 0), "Spenders and amounts array length should be non-zero and same");
-        for (uint256 i = 0; i < spenders.length; ++i)
-        {
-            approveFor(owner, authorized, spenders[i], amounts[i]);
-        }
-    }
-    */
 }

--- a/contracts/ERC20AuthorizedClient.sol
+++ b/contracts/ERC20AuthorizedClient.sol
@@ -29,10 +29,28 @@ abstract contract ERC20AuthorizedClient is ERC20
      * @param authorized - existing address authorized by caller
      * @return authorization cap or 0 if not authorized
      */
-    function GetAuthorizedCap(address authorized) view public returns (uint256)
+    function getAuthorizedCap(address authorized) view public returns (uint256)
     {
         return IERC20Authorized(authorizationServerAddr).getAuthorizedCap(
             address(this), msg.sender, authorized);
+    }
+
+    /**
+     * @return a list of addresses that are currently authorized by the caller (owner)
+     */
+    function getAuthorizersList() public view returns (address[] memory)
+    {
+        return IERC20Authorized(authorizationServerAddr).getAuthorizersList(
+            address(this),  msg.sender);
+    }
+
+    /**
+     * @return a list of addresses that are currently delegating the caller (authorized user)
+     */
+    function getOwnersList() public view returns (address[] memory)
+    {
+        return IERC20Authorized(authorizationServerAddr).getOwnersList(
+            address(this),  msg.sender);
     }
 
     /**
@@ -40,8 +58,7 @@ abstract contract ERC20AuthorizedClient is ERC20
      * @param owner - The address that already authorized the caller
      * @return authorization cap or 0 if not authorized
      */
-
-    function GetAuthorizedByCap(address owner) view public returns (uint256)
+    function getAuthorizedByCap(address owner) view public returns (uint256)
     {
         return IERC20Authorized(authorizationServerAddr).getAuthorizedCap(
             address(this), owner, msg.sender);
@@ -75,7 +92,7 @@ abstract contract ERC20AuthorizedClient is ERC20
      */
     function increaseAuthorizedCap(address authorized, uint256 addedCap) public
     {
-        uint256 currentCap = GetAuthorizedCap(authorized);
+        uint256 currentCap = getAuthorizedCap(authorized);
         uint256 clientNewCap = _getIncreasedCap(currentCap, addedCap);
         approve(authorized, clientNewCap);
         uint256 serverNewCap = IERC20Authorized(authorizationServerAddr).increaseAuthorizedCap(
@@ -105,7 +122,7 @@ abstract contract ERC20AuthorizedClient is ERC20
 
     function _decreaseAuthorizedCap(address from, address authorized, uint256 subtractedCap) internal
     {
-        uint256 currentCap = GetAuthorizedCap(authorized);
+        uint256 currentCap = getAuthorizedCap(authorized);
         (uint256 clientNewCap, ) = _getDecreasedCap(currentCap, subtractedCap);
         approve(authorized, clientNewCap);
         uint256 serverNewCap = IERC20Authorized(authorizationServerAddr).decreaseAuthorizedCap(
@@ -133,14 +150,6 @@ abstract contract ERC20AuthorizedClient is ERC20
     }
 
     /**
-     * @return true this client is currently registered with Authorization features
-     */
-    function isRegisteredClient() external view returns (bool)
-    {
-        return IERC20Authorized(authorizationServerAddr).isRegisteredClient(address(this));
-    }
-
-    /**
      * @dev A function for authorized users to verify authorization from a specific owner
      * @param owner - address that authorized the caller
      * @return true when authorized address have a positive cap
@@ -152,11 +161,19 @@ abstract contract ERC20AuthorizedClient is ERC20
     }
 
     /**
+     * @return true this client is currently registered with Authorization features
+     */
+    function isRegisteredClient() public view returns (bool)
+    {
+        return IERC20Authorized(authorizationServerAddr).isRegisteredClient(address(this));
+    }
+
+    /**
      * Registers the client
      */
-    function registerClient() external payable
+    function registerClient() public payable
     {
-        IERC20Authorized(authorizationServerAddr).registerClient{value: msg.value}(address(this));
+        IERC20Authorized(authorizationServerAddr).registerClient{value: msg.value}();
     }
 
     /**
@@ -176,7 +193,7 @@ abstract contract ERC20AuthorizedClient is ERC20
      */
     function approveFor(address owner, address spender, uint256 amount) public
     {
-        uint256 currentCap = GetAuthorizedByCap(owner);
+        uint256 currentCap = getAuthorizedByCap(owner);
         (uint256 clientNewCap, uint256 clientApprovedAmount) =
                         _getDecreasedCap(currentCap, amount);
         _approve(owner, msg.sender, clientNewCap);
@@ -197,7 +214,6 @@ abstract contract ERC20AuthorizedClient is ERC20
             "Spenders and amounts array length should be non-zero and same");
         for (uint256 i = 0; i < spenders.length; ++i)
         {
-            // TODO: consider maybe not revert all if some approvals fail
             approveFor(owner, spenders[i], amounts[i]);
         }
     }

--- a/contracts/ERC20AuthorizedErrors.sol
+++ b/contracts/ERC20AuthorizedErrors.sol
@@ -7,12 +7,27 @@ contract ERC20AuthorizedErrors
     // instead
     error AlreadyAuthorized(address client, address owner, address authorized);
 
+    // Thrown when trying to register a client address already registered in the server
+    error AlreadyRegistered(address client);
+
+    // Thrown when a non-registered client tries to interact with authorization features
+    error ClientNotRegistered(address client);
+
+    // Thrown when the trying to register on an exhausted client pool
+    error ClientPoolExhuasted(uint256 clientPoolRemaining, uint256 registerationAuthdAmount);
+
     // Thrown when requested amount is invalid
     error InvalidAmount(uint256 amount);
+
+    // Thrown when there is not enough AUTHD tokens in the server supply
+    error InsufficientAuthdSupply(uint256 supply, uint256 registerationAuthdAmount);
 
     // Thrown when an authorized address (by owner in client) tries to approve on more than its cap
     error InsufficientAuthorizedCap(address client, address owner, address authroized, uint256 currentCap,
         uint256 amountRequested);
+
+    // Thrown when a client tries to register and doesn't supply the minimal registration fee
+    error InsufficientRegistrationFee(uint256 providedFee, uint256 registerationFee);
 
     // Thrown when trying to authorize on insufficient owner balance in client
     error InsufficientOwnerBalance(address client, address owner, uint256 capAmount);

--- a/contracts/interfaces/IERC20Authorized.sol
+++ b/contracts/interfaces/IERC20Authorized.sol
@@ -3,15 +3,34 @@ pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-/// These are all the functions that will be called from the client, but they will be implemented by the server as well
+/// Non view function will be called by a client. View function could be called from any user
 interface IERC20Authorized is IERC20
 {
-    /// Should be called by owner
+    /*
+     * Registration / treasury events
+     */
+    event ClientRegistered(address indexed client, uint256 ethPaid, uint256 authdSent);
+    event ClientRegistrationRevoked(address indexed client);
+    event TreasuryWithdrawal(address indexed to, uint256 amount);
+
+    /*
+     * INTERFACE / AUTHORIZATION EVENTS
+     */
+    event Authorization(address indexed client, address indexed owner, address authorized, uint256 cap);
+    event RevokeAuthorization(address indexed client, address indexed owner, address authorized);
+    event IncreaseAuthorizedCap(address indexed client, address indexed owner, address authorized, uint256 newCap);
+    event DecreaseAuthorizedCap(address indexed client, address indexed owner, address authorized, uint256 newCap);
+    event ApproveFor(address indexed client, address indexed owner, address authorized, address spender, uint256 approvedAmount);
+
+    function approveFor(address owner, address authorized, address spender, uint256 amount) external returns (uint256);
+
     function authorize(address owner, address authorized, uint256 cap) external;
 
     function getAuthorizedCap(address client, address owner, address authorized) view external returns (uint256);
 
     function getAuthorizersList(address client, address owner) external view returns (address[] memory);
+
+    function getOwnersList(address client, address authorized) external view returns (address[] memory);
 
     function getRegistrationFee() external view returns (uint256);
 
@@ -23,13 +42,9 @@ interface IERC20Authorized is IERC20
 
     function isRegisteredClient(address client) external view returns (bool);
 
-    function registerClient(address client) external payable;
+    function registerClient() external payable;
 
     function revokeAuthorization(address owner, address authorized) external;
 
-    function approveFor(address owner, address authorized, address spender, uint256 amount) external returns (uint256);
-
-    // TODO: Consider moving this functionality to Client
-    // Supports approving multiple spenders in a single transaction
-    // function approveFor(address owner, address authorized, address[] calldata spenders, uint256[] calldata amounts) external;
+    function revokeClientRegistration(address client) external;
 }

--- a/test/ERC20Authorized.t.sol
+++ b/test/ERC20Authorized.t.sol
@@ -4,19 +4,10 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {ERC20Authorized} from "../contracts/ERC20Authorized.sol";
+import {IERC20Authorized} from "../contracts/interfaces/IERC20Authorized.sol";
+import {ERC20AuthorizedErrors} from "../contracts/ERC20AuthorizedErrors.sol";
 
-interface IERC20AuthorizedEvents
-{
-    event Authorization(address indexed, address indexed, address, uint256);
-    event RevokeAuthorization(address indexed, address indexed, address);
-    event IncreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event DecreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event ApproveFor(address indexed, address indexed, address, address, uint256);
-    event ClientRegistered(address indexed client, address indexed payer, uint256 ethPaid, uint256 authdSent);
-    event TreasuryWithdrawal(address indexed to, uint256 amount);
-}
-
-contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
+contract ERC20AuthorizedTest is Test
 {
     ERC20Authorized public erc20Authorized;
     ERC20Authorized public customToken1;
@@ -32,15 +23,14 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         customToken2 = new ERC20Authorized();
         uint256 fee1 = erc20Authorized.getRegistrationFee();
         uint256 fee2 = erc20Authorized.getRegistrationFee();
-        // Register both fake client contracts so authorize/increase/decrease/etc can be called
-        erc20Authorized.registerClient{value: fee1}(address(customToken1));
-        erc20Authorized.registerClient{value: fee2}(address(customToken2));
+        // Register both dummy client contracts so authorize/increase/decrease/etc can be called
+        vm.deal(address(customToken1), fee1);
+        vm.prank(address(customToken1));
+        erc20Authorized.registerClient{value: fee1}();
+        vm.deal(address(customToken2), fee2);
+        vm.prank(address(customToken2));
+        erc20Authorized.registerClient{value: fee2}();
     }
-
-    // MIGHT BE USEFUL later:
-    //        customToken1.transfer(owner, 50);
-    //        assertEq(customToken1.balanceOf(owner), 50);
-
 
     function test_authorizeInvalidAddress() external
     {
@@ -96,21 +86,11 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
     {
         deal(address(customToken1), owner, 50);
         vm.prank(address(customToken1));
+        vm.expectEmit(true, true, false, true);
+        emit IERC20Authorized.Authorization(address(customToken1), owner, authorized1, 50);
         erc20Authorized.authorize(owner, authorized1, 50);
         // Verify cap updates
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 50, "Cap should updated after authorizing");
-        // TODO: Move to Client tests
-        // Verify authorization automatically approves authorized
-        //assertEq(customToken.allowance(owner, authorized1), 50, "Authorization should approve authorized");
-    }
-
-    function test_authorizeEventEmitted() external
-    {
-        deal(address(customToken1), owner, 50);
-        vm.prank(address(customToken1));
-        vm.expectEmit(true, true, false, true);
-        emit Authorization(address(customToken1), owner, authorized1, 50);
-        erc20Authorized.authorize(owner, authorized1, 50);
     }
 
     function test_authorizeDouble() external
@@ -142,6 +122,30 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         assertEq(erc20Authorized.getAuthorizersList(address(customToken1), owner), authorizers);
     }
 
+    function test_getOwnersList() external
+    {
+        address owner2 = makeAddr("Owner-address-2");
+        deal(address(customToken1), owner, 50);
+        deal(address(customToken1), owner2, 75);
+        vm.startPrank(address(customToken1));
+        erc20Authorized.authorize(owner, authorized1, 10);
+        erc20Authorized.authorize(owner2, authorized1, 20);
+        erc20Authorized.authorize(owner, authorized2, 15);
+        address[] memory ownersAuthorized1 =  new address[](2);
+        ownersAuthorized1[0] = owner;
+        ownersAuthorized1[1] = owner2;
+        assertEq(erc20Authorized.getOwnersList(address(customToken1), authorized1), ownersAuthorized1);
+        address[] memory ownersAuthorized2 =  new address[](1);
+        ownersAuthorized2[0] = owner;
+        assertEq(erc20Authorized.getOwnersList(address(customToken1), authorized2), ownersAuthorized2);
+        // Verify owners list is updated after revoking authorization
+        erc20Authorized.revokeAuthorization(owner, authorized1);
+        delete ownersAuthorized1;
+        ownersAuthorized1 =  new address[](1);
+        ownersAuthorized1[0] = owner2;
+        assertEq(erc20Authorized.getOwnersList(address(customToken1), authorized1), ownersAuthorized1);
+    }
+
     function test_revokeUnauthorized() external
     {
         deal(address(customToken1), owner, 50);
@@ -159,7 +163,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
 
         // Verify revoke works
         vm.expectEmit(true, true, false, true);
-        emit RevokeAuthorization(address(customToken1), owner, authorized1);
+        emit IERC20Authorized.RevokeAuthorization(address(customToken1), owner, authorized1);
         erc20Authorized.revokeAuthorization(owner, authorized1);
         assertFalse(erc20Authorized.isAuthorized(address(customToken1), owner, authorized1));
 
@@ -289,21 +293,21 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, 10);
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 10, "Cap should updated after authorizing");
         vm.expectEmit(true, true, false, true);
-        emit IncreaseAuthorizedCap(address(customToken1), owner, authorized1, 60);
+        emit IERC20Authorized.IncreaseAuthorizedCap(address(customToken1), owner, authorized1, 60);
         uint256 newCap = erc20Authorized.increaseAuthorizedCap(owner, authorized1, 50);
         assertEq(newCap, 60, "returned value from increase should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 60, "Cap should updated after increase");
         vm.expectEmit(true, true, false, true);
-        emit IncreaseAuthorizedCap(address(customToken1), owner, authorized1, 80);
+        emit IERC20Authorized.IncreaseAuthorizedCap(address(customToken1), owner, authorized1, 80);
         erc20Authorized.increaseAuthorizedCap(owner, authorized1, 20);
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 80, "Cap should updated after increase");
         vm.expectEmit(true, true, false, true);
-        emit DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 30);
+        emit IERC20Authorized.DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 30);
         newCap = erc20Authorized.decreaseAuthorizedCap(owner, authorized1, 50);
         assertEq(newCap, 30, "returned value from decrease should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 30, "Cap should updated after decrease");
         vm.expectEmit(true, true, false, true);
-        emit DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 20);
+        emit IERC20Authorized.DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 20);
         erc20Authorized.decreaseAuthorizedCap(owner, authorized1, 10);
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 20, "Cap should updated after decrease");
     }
@@ -317,7 +321,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         vm.startPrank(address(customToken1));
         erc20Authorized.authorize(owner, authorized1, 50);
         vm.expectEmit(true, true, false, true);
-        emit IncreaseAuthorizedCap(address(customToken1), owner, authorized1, maxInt);
+        emit IERC20Authorized.IncreaseAuthorizedCap(address(customToken1), owner, authorized1, maxInt);
         uint256 newCap = erc20Authorized.increaseAuthorizedCap(owner, authorized1, maxInt);
         assertEq(newCap, maxInt, "returned value from increase should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), maxInt, "Cap should clip overflow to maxInt on increase");
@@ -330,7 +334,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         vm.startPrank(address(customToken1));
         erc20Authorized.authorize(owner, authorized1, amount / 2);
         vm.expectEmit(true, true, false, true);
-        emit DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 0);
+        emit IERC20Authorized.DecreaseAuthorizedCap(address(customToken1), owner, authorized1, 0);
         uint256 newCap = erc20Authorized.decreaseAuthorizedCap(owner, authorized1, amount / 2);
         assertEq(newCap, 0, "returned value from decrease should be the new cap");
         assertEq(erc20Authorized.getAuthorizedCap(address(customToken1), owner, authorized1), 0, "Cap should decrease");
@@ -400,7 +404,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, amount / 2);
         vm.recordLogs();
         vm.expectEmit(true, true, false, true);
-        emit ApproveFor(address(customToken1), owner,  authorized1, authorized2, 0);
+        emit IERC20Authorized.ApproveFor(address(customToken1), owner,  authorized1, authorized2, 0);
         erc20Authorized.approveFor(owner, authorized1, authorized2, 0);
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries.length, 2, "Only 2 events should have been emitted");
@@ -424,9 +428,9 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
         erc20Authorized.authorize(owner, authorized1, amount);
         vm.recordLogs();
         vm.expectEmit(true, true, false, true);
-        emit DecreaseAuthorizedCap(address(customToken1), owner,  authorized1, 3 * amount / 4);
+        emit IERC20Authorized.DecreaseAuthorizedCap(address(customToken1), owner,  authorized1, 3 * amount / 4);
         vm.expectEmit(true, true, false, true);
-        emit ApproveFor(address(customToken1), owner,  authorized1, authorized2, amount / 4);
+        emit IERC20Authorized.ApproveFor(address(customToken1), owner,  authorized1, authorized2, amount / 4);
         erc20Authorized.approveFor(owner, authorized1, authorized2, amount / 4);
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries.length, 4, "Only 4 events should have been emitted");
@@ -464,34 +468,41 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
             ERC20Authorized newClient = new ERC20Authorized();
             uint256 fee = erc20Authorized.getRegistrationFee();
             uint256 authdAmount = erc20Authorized.REGISTRATION_AUTHD_AMOUNT();
-            vm.expectEmit(true, true, false, true);
-            emit ClientRegistered(address(newClient), address(this), fee, authdAmount);
+            vm.deal(address(newClient), fee);
+            vm.startPrank(address(newClient));
+            vm.expectEmit(true, false, false, true);
+            emit IERC20Authorized.ClientRegistered(address(newClient),  fee, authdAmount);
+            erc20Authorized.registerClient{value: fee}();
 
-            erc20Authorized.registerClient{value: fee}(address(newClient));
-
-            assertTrue(erc20Authorized.registeredClients(address(newClient)));
+            assertTrue(erc20Authorized.isRegisteredClient(address(newClient)));
             assertEq(erc20Authorized.balanceOf(address(newClient)), authdAmount);
         }
 
     function test_registerClientRevertsIfZeroAddress() external
         {
+            vm.deal(address(0), 0.01 ether);
+            vm.startPrank(address(0));
             vm.expectRevert();
-            erc20Authorized.registerClient{value: 0.01 ether}(address(0));
+            erc20Authorized.registerClient{value: 0.01 ether}();
         }
 
     function test_registerClientRevertsIfAlreadyRegistered() external
         {
+            vm.deal(address(customToken1), 0.01 ether);
+            vm.startPrank(address(customToken1));
             vm.expectRevert();
-            erc20Authorized.registerClient{value: 0.01 ether}(address(customToken1));
+            erc20Authorized.registerClient{value: 0.01 ether}();
         }
 
     function test_registerClientRevertsIfInsufficientFee() external {
             address client = makeAddr("client");
             uint256 fee = erc20Authorized.getRegistrationFee();
-
-            vm.expectRevert(bytes("Insufficient registration fee"));
-            erc20Authorized.registerClient{value: fee - 1}(client);
+            vm.deal(client, fee - 1);
+            vm.prank(client);
+            vm.expectRevert(abi.encodeWithSelector(ERC20AuthorizedErrors.InsufficientRegistrationFee.selector, fee - 1, fee));
+            erc20Authorized.registerClient{value: fee - 1}();
         }
+
     function test_isRegisteredClientWorks() external
         {
             assertTrue(erc20Authorized.isRegisteredClient(address(customToken1)));
@@ -555,7 +566,7 @@ contract ERC20AuthorizedTest is Test, IERC20AuthorizedEvents
             uint256 treasuryBalance = address(erc20Authorized).balance;
 
             vm.expectEmit(true, false, false, true, address(erc20Authorized));
-            emit TreasuryWithdrawal(treasuryReceiver, treasuryBalance);
+            emit IERC20Authorized.TreasuryWithdrawal(treasuryReceiver, treasuryBalance);
 
             erc20Authorized.withdrawTreasury(treasuryReceiver);
 

--- a/test/ERC20AuthorizedClient.t.sol
+++ b/test/ERC20AuthorizedClient.t.sol
@@ -2,25 +2,15 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-// import {Vm} from "forge-std/Vm.sol";
 import {DemoClient} from "./DemoClient.sol";
 import {ERC20Authorized} from "../contracts/ERC20Authorized.sol";
+import {IERC20Authorized} from "../contracts/interfaces/IERC20Authorized.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-interface IERC20AuthorizedEvents
-{
-    event Authorization(address indexed, address indexed, address, uint256);
-    event RevokeAuthorization(address indexed, address indexed, address);
-    event IncreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-    event DecreaseAuthorizedCap(address indexed, address indexed, address, uint256);
-   event ApproveFor(address indexed, address indexed, address, address, uint256);
-}
-
-contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
+contract AuthorizedClientTest is Test
 {
     ERC20Authorized public authorizedServer;
     DemoClient public demoClient1;
-    // ERC20AuthorizedClient public demoClient2;
     address internal owner = makeAddr("Owner-address");
     address internal authorized1 = makeAddr("Authorized-address-1");
     address internal authorized2 = makeAddr("Authorized-address-2");
@@ -43,10 +33,10 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.expectEmit(true, true, false, true);
         emit IERC20.Approval( owner,  authorized1, 25);
         vm.expectEmit(true, true, false, true);
-        emit Authorization(address(demoClient1), owner, authorized1, 25);
+        emit IERC20Authorized.Authorization(address(demoClient1), owner, authorized1, 25);
         demoClient1.authorize(authorized1, 25);
         assertTrue(demoClient1.isAuthorized(authorized1));
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 25, "Cap should update after authorize");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 25, "Cap should update after authorize");
         // Verify authorized address calls ERC20's approval
         assertEq(demoClient1.allowance(owner, authorized1), 25, "Authorized should be approved on the authorized cap");
     }
@@ -60,9 +50,9 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.expectEmit(true, true, false, true);
         emit IERC20.Approval( owner,  authorized1, 45);
         vm.expectEmit(true, true, false, true);
-        emit IncreaseAuthorizedCap(address(demoClient1), owner, authorized1, 45);
+        emit IERC20Authorized.IncreaseAuthorizedCap(address(demoClient1), owner, authorized1, 45);
         demoClient1.increaseAuthorizedCap(authorized1, 20);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 45, "Cap should update after increase");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 45, "Cap should update after increase");
         // Verify authorized address increase calls ERC20's approval
         assertEq(demoClient1.allowance(owner, authorized1), 45, "Authorized should be approved on the updated authorized cap");
     }
@@ -74,7 +64,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.startPrank(owner);
         demoClient1.authorize(authorized1, 100);
         demoClient1.increaseAuthorizedCap(authorized1, maxInt);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), maxInt, "Cap should update after increase");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), maxInt, "Cap should update after increase");
         // Verify authorized address increase calls ERC20's approval
         assertEq(demoClient1.allowance(owner, authorized1), maxInt, "Authorized should be approved on the updated authorized cap");
     }
@@ -88,9 +78,9 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.expectEmit(true, true, false, true);
         emit IERC20.Approval( owner,  authorized1, 10);
         vm.expectEmit(true, true, false, true);
-        emit DecreaseAuthorizedCap(address(demoClient1), owner, authorized1, 10);
+        emit IERC20Authorized.DecreaseAuthorizedCap(address(demoClient1), owner, authorized1, 10);
         demoClient1.decreaseAuthorizedCap(authorized1, 15);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 10, "Cap should update after decrease");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 10, "Cap should update after decrease");
         // Verify authorized address increase calls ERC20's approval
         assertEq(demoClient1.allowance(owner, authorized1), 10, "Authorized should be approved on the updated authorized cap");
     }
@@ -101,7 +91,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.startPrank(owner);
         demoClient1.authorize(authorized1, 50);
         demoClient1.decreaseAuthorizedCap(authorized1, 100);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 0, "Cap should update after decrease");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 0, "Cap should update after decrease");
         // Verify authorized address increase calls ERC20's approval
         assertEq(demoClient1.allowance(owner, authorized1), 0, "Authorized should be approved on the updated authorized cap");
     }
@@ -117,7 +107,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         demoClient1.revokeAuthorization(authorized1);
         vm.startPrank(owner);
         vm.expectEmit(true, true, false, true);
-        emit RevokeAuthorization(address(demoClient1), owner, authorized1);
+        emit IERC20Authorized.RevokeAuthorization(address(demoClient1), owner, authorized1);
         demoClient1.revokeAuthorization(authorized1);
         assertFalse(demoClient1.isAuthorized(authorized1), "Revoking should un-authorize");
         // Verify authorized address increase calls ERC20's approval
@@ -144,12 +134,12 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.expectEmit(true, true, false, true);
         emit IERC20.Approval( owner,  spender1, 15);
         vm.expectEmit(true, true, false, true);
-        emit DecreaseAuthorizedCap(address(demoClient1), owner, authorized1,10);
+        emit IERC20Authorized.DecreaseAuthorizedCap(address(demoClient1), owner, authorized1,10);
         vm.expectEmit(true, true, false, true);
-        emit ApproveFor(address(demoClient1), owner, authorized1, spender1, 15);
+        emit IERC20Authorized.ApproveFor(address(demoClient1), owner, authorized1, spender1, 15);
         demoClient1.approveFor(owner, spender1, 15);
         vm.prank(owner);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 10, "Cap should update after approve");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 10, "Cap should update after approve");
         // Verify authorized address increase calls ERC20's approval
         assertEq(demoClient1.allowance(owner, authorized1), 10, "Authorized should be approved on the updated authorized cap");
         assertEq(demoClient1.allowance(owner, spender1), 15, "Spender allowance should be updated");
@@ -195,8 +185,8 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.prank(authorized2);
         demoClient1.approveFor(owner, spender1, 75);
         vm.startPrank(owner);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 50, "Cap should update after approve");
-        assertEq(demoClient1.GetAuthorizedCap(authorized2), 25, "Cap should update after approve");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 50, "Cap should update after approve");
+        assertEq(demoClient1.getAuthorizedCap(authorized2), 25, "Cap should update after approve");
         assertEq(demoClient1.allowance(owner, authorized1), 50, "Authorized1 allowance should be updated");
         assertEq(demoClient1.allowance(owner, authorized2), 25, "Authorized2 allowance should be updated");
         assertEq(demoClient1.allowance(owner, spender1), 75, "Spender allowance should be updated according the most recent approval");
@@ -274,7 +264,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.prank(authorized1);
         demoClient1.approveForMultiple(owner, spenders, amounts);
         vm.prank(owner);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), amount / 4, "Cap should update after approve");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), amount / 4, "Cap should update after approve");
         assertEq(demoClient1.allowance(owner, authorized1), amount / 4, "Authorized1 allowance should be updated");
         assertEq(demoClient1.allowance(owner, spender1), amount / 2, "Spender1 allowance should be updated");
         assertEq(demoClient1.allowance(owner, spender2), amount / 4, "Spender2 allowance should be updated");
@@ -296,7 +286,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.prank(authorized1);
         demoClient1.approveForMultiple(owner, spenders, amounts);
         vm.prank(owner);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), amount / 4, "Cap should update after approve");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), amount / 4, "Cap should update after approve");
         assertEq(demoClient1.allowance(owner, authorized1), amount / 4, "Authorized1 allowance should be updated");
         assertEq(demoClient1.allowance(owner, spender1), amount / 4, "Spender allowance should be updated according the most recent approval");
     }
@@ -308,18 +298,18 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         demoClient1.authorize(authorized1, 100);
         demoClient1.authorize(authorized2, 200);
         demoClient1.transfer(address(this), 50);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 100, "Cap should not update if not needed after transfer");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 100, "Cap should not update if not needed after transfer");
         assertEq(demoClient1.allowance(owner, authorized1),100, "Authorized1 allowance should not be updated");
-        assertEq(demoClient1.GetAuthorizedCap(authorized2), 150, "Cap should update after transfer");
+        assertEq(demoClient1.getAuthorizedCap(authorized2), 150, "Cap should update after transfer");
         assertEq(demoClient1.allowance(owner, authorized2), 150, "Authorized2 allowance should be updated");
         vm.stopPrank();
         vm.prank(authorized1);
         demoClient1.approveFor(owner, spender1, 60);
         vm.startPrank(owner);
         demoClient1.transfer(address(this), 100);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 40, "Cap should not be needed after transfer");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 40, "Cap should not be needed after transfer");
         assertEq(demoClient1.allowance(owner, authorized1),40, "Authorized1 allowance shouldn't be updated");
-        assertEq(demoClient1.GetAuthorizedCap(authorized2), 50, "Cap should update after transfer to owner's balance");
+        assertEq(demoClient1.getAuthorizedCap(authorized2), 50, "Cap should update after transfer to owner's balance");
         assertEq(demoClient1.allowance(owner, authorized2), 50, "Authorized2 allowance should be updated to owner's balance");
         assertEq(demoClient1.allowance(owner, spender1), 60, "spender allowance should not be updated during _update");
     }
@@ -330,7 +320,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         vm.startPrank(owner);
         demoClient1.authorize(authorized1, 100);
         demoClient1.burn(150);
-        assertEq(demoClient1.GetAuthorizedCap(authorized1), 50, "Cap should update after burn");
+        assertEq(demoClient1.getAuthorizedCap(authorized1), 50, "Cap should update after burn");
         assertEq(demoClient1.allowance(owner, authorized1),50, "Authorized1 allowance should be updated");
     }
 
@@ -344,7 +334,7 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         // Verify there is no issue with revoked authorizer
         demoClient1.transfer(address(this), 120);
         assertFalse(demoClient1.isAuthorized(authorized1));
-        assertEq(demoClient1.GetAuthorizedCap(authorized2), 80, "Cap should update after transfer");
+        assertEq(demoClient1.getAuthorizedCap(authorized2), 80, "Cap should update after transfer");
         assertEq(demoClient1.allowance(owner, authorized2), 80, "Authorized2 allowance should be updated");
     }
 
@@ -367,5 +357,52 @@ contract AuthorizedClientTest is Test, IERC20AuthorizedEvents
         demoClient2.decreaseAuthorizedCap(authorized1, 50);
         assertFalse(demoClient2.isRegisteredClient());
         assertTrue(demoClient1.isRegisteredClient());
+    }
+
+    function test_getAuthorizersList() external
+    {
+        deal(address(demoClient1), owner, 50);
+        vm.startPrank(owner);
+        demoClient1.authorize(authorized1, 10);
+        demoClient1.authorize(authorized2, 20);
+        address[] memory authorizers =  new address[](2);
+        authorizers[0] = authorized1;
+        authorizers[1] = authorized2;
+        assertEq(demoClient1.getAuthorizersList(), authorizers);
+        demoClient1.revokeAuthorization(authorized1);
+        delete authorizers;
+        authorizers =  new address[](1);
+        authorizers[0] = authorized2;
+        assertEq(demoClient1.getAuthorizersList(), authorizers);
+    }
+
+    function test_getOwnersList() external
+    {
+        address owner2 = makeAddr("Owner-address-2");
+        deal(address(demoClient1), owner, 50);
+        deal(address(demoClient1), owner2, 75);
+        vm.prank(owner);
+        demoClient1.authorize(authorized1, 10);
+        vm.prank(owner);
+        demoClient1.authorize(authorized2, 15);
+        vm.prank(owner2);
+        demoClient1.authorize(authorized1, 20);
+        address[] memory ownersAuthorized1 =  new address[](2);
+        ownersAuthorized1[0] = owner;
+        ownersAuthorized1[1] = owner2;
+        vm.prank(authorized1);
+        assertEq(demoClient1.getOwnersList(), ownersAuthorized1);
+        address[] memory ownersAuthorized2 =  new address[](1);
+        ownersAuthorized2[0] = owner;
+        vm.prank(authorized2);
+        assertEq(demoClient1.getOwnersList(), ownersAuthorized2);
+        // Verify owners list is updated after revoking authorization
+        vm.prank(owner);
+        demoClient1.revokeAuthorization(authorized1);
+        delete ownersAuthorized1;
+        ownersAuthorized1 =  new address[](1);
+        ownersAuthorized1[0] = owner2;
+        vm.prank(authorized1);
+        assertEq(demoClient1.getOwnersList(), ownersAuthorized1);
     }
 }


### PR DESCRIPTION
This is the parliamentary commit that sets everything for the Front-End interface and the integration with a real ERC20 token. 

Server: add support for owners list of addresses given an authorized address (for Front-End dashboard). add unittest for getOwnersList.

Interface: move events to interface. cleanups. Interface verification. Update visibility for storage variables.
Client: add interface functions getAuthorizersList and getOwnersList and unittests.